### PR TITLE
Auto-spider highlighted map markers

### DIFF
--- a/src/app/components/Map.tsx
+++ b/src/app/components/Map.tsx
@@ -412,7 +412,32 @@ const Map: React.FC<MapProps> = ({ journey, selectedDayId, onLocationClick }) =>
       return next;
     });
   }, [groups]);
-  
+
+  useEffect(() => {
+    if (!closestLocation) return;
+
+    const highlightedGroup = groups.find(group =>
+      group.items.some(({ location }) => location.id === closestLocation.id)
+    );
+
+    if (!highlightedGroup || highlightedGroup.items.length <= 1) {
+      return;
+    }
+
+    if (expandedGroups.has(highlightedGroup.key)) {
+      return;
+    }
+
+    setExpandedGroups(prev => {
+      if (prev.has(highlightedGroup.key)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.add(highlightedGroup.key);
+      return next;
+    });
+  }, [closestLocation?.id, groups, expandedGroups]);
+
   if (!journey) {
     return (
       <div className="h-full flex items-center justify-center bg-gray-100 dark:bg-gray-800">

--- a/src/app/map/[id]/components/EmbeddableMap.tsx
+++ b/src/app/map/[id]/components/EmbeddableMap.tsx
@@ -499,6 +499,13 @@ const EmbeddableMap: React.FC<EmbeddableMapProps> = ({ travelData }) => {
       const state = groupLayers.get(groupKey);
       if (!state) return;
 
+      const containsHighlighted = closestLocation
+        ? state.group.items.some(location => location.id === closestLocation.id)
+        : false;
+      if (containsHighlighted) {
+        return;
+      }
+
       state.childMarkers.forEach(marker => marker.remove());
       state.childMarkers = [];
       state.legs.forEach(leg => leg.remove());
@@ -555,6 +562,13 @@ const EmbeddableMap: React.FC<EmbeddableMapProps> = ({ travelData }) => {
         if (!validKeys.has(key)) {
           expanded.delete(key);
         }
+      }
+
+      const highlightedGroup = closestLocation
+        ? groups.find(group => group.items.some(location => location.id === closestLocation.id))
+        : undefined;
+      if (highlightedGroup && highlightedGroup.items.length > 1 && !expanded.has(highlightedGroup.key)) {
+        expanded.add(highlightedGroup.key);
       }
 
       groups.forEach(group => {


### PR DESCRIPTION
## Summary
- automatically expand grouped markers that contain the highlighted current-location marker in the main map
- ensure embeddable maps auto-spider highlighted markers and prevent collapsing groups that contain the highlighted stop

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911f7d4592483338bdcab623677425d)