### PR TITLE
Collapse past admin locations by default

### DIFF
--- a/src/app/admin/components/LocationDisplay.tsx
+++ b/src/app/admin/components/LocationDisplay.tsx
@@ -16,6 +16,9 @@ interface LocationDisplayProps {
   showAccommodations?: boolean;
   linkedExpenses?: Array<{ description: string; amount: number; currency: string }>;
   tripId?: string; // Optional for backward compatibility
+  className?: string;
+  frameless?: boolean;
+  showHeader?: boolean;
 }
 
 export default function LocationDisplay({
@@ -25,7 +28,10 @@ export default function LocationDisplay({
   onViewPosts,
   showAccommodations = false,
   linkedExpenses = [],
-  tripId
+  tripId,
+  className,
+  frameless = false,
+  showHeader = true
 }: LocationDisplayProps) {
   const formatDate = (date: string | Date) => {
     return formatUtcDate(date, 'en-GB', {
@@ -53,57 +59,67 @@ export default function LocationDisplay({
 
   const hasCoords = location.coordinates[0] !== 0 || location.coordinates[1] !== 0;
 
+  const containerClassName = [
+    frameless
+      ? ''
+      : 'border border-gray-200 dark:border-gray-600 rounded-lg p-4 bg-white dark:bg-gray-800 hover:shadow-md transition-shadow',
+    className
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <div className="border border-gray-200 dark:border-gray-600 rounded-lg p-4 bg-white dark:bg-gray-800 hover:shadow-md transition-shadow">
-      {/* Header */}
-      <div className="flex justify-between items-start mb-2">
-        <div className="flex-1">
-          <h4 className="font-semibold text-gray-900 dark:text-white text-lg">
-            {location.name}
-          </h4>
-          <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
-            {location.endDate ? (
-              <span>
-                {formatDate(location.date)} - {formatDate(location.endDate)}
-                {location.duration && (
-                  <span className="ml-2 text-xs text-blue-600 dark:text-blue-400">
-                    ({formatDuration(location.duration, location.date, location.endDate)})
-                  </span>
-                )}
-              </span>
-            ) : (
-              formatDate(location.date)
+    <div className={containerClassName || undefined}>
+      {showHeader && (
+        <div className="flex justify-between items-start mb-2">
+          <div className="flex-1">
+            <h4 className="font-semibold text-gray-900 dark:text-white text-lg">
+              {location.name}
+            </h4>
+            <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+              {location.endDate ? (
+                <span>
+                  {formatDate(location.date)} - {formatDate(location.endDate)}
+                  {location.duration && (
+                    <span className="ml-2 text-xs text-blue-600 dark:text-blue-400">
+                      ({formatDuration(location.duration, location.date, location.endDate)})
+                    </span>
+                  )}
+                </span>
+              ) : (
+                formatDate(location.date)
+              )}
+            </div>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex gap-2 ml-4">
+            {onViewPosts && (
+              <button
+                onClick={onViewPosts}
+                className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
+                title="View/Add Posts"
+              >
+                Posts ({(location.instagramPosts?.length || 0) + (location.blogPosts?.length || 0)})
+              </button>
+            )}
+            <button
+              onClick={onEdit}
+              className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
+            >
+              Edit
+            </button>
+            {onDelete && (
+              <button
+                onClick={onDelete}
+                className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 text-sm font-medium"
+              >
+                Delete
+              </button>
             )}
           </div>
         </div>
-
-        {/* Action Buttons */}
-        <div className="flex gap-2 ml-4">
-          {onViewPosts && (
-            <button
-              onClick={onViewPosts}
-              className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
-              title="View/Add Posts"
-            >
-              Posts ({(location.instagramPosts?.length || 0) + (location.blogPosts?.length || 0)})
-            </button>
-          )}
-          <button
-            onClick={onEdit}
-            className="text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-sm font-medium"
-          >
-            Edit
-          </button>
-          {onDelete && (
-            <button
-              onClick={onDelete}
-              className="text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 text-sm font-medium"
-            >
-              Delete
-            </button>
-          )}
-        </div>
-      </div>
+      )}
 
       {/* Location Details */}
       <div className="space-y-2">

--- a/src/app/admin/edit/[tripId]/components/location/LocationItem.tsx
+++ b/src/app/admin/edit/[tripId]/components/location/LocationItem.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Location } from '@/app/types';
 import { CostTrackingData } from '@/app/types';
 import { ExpenseTravelLookup } from '@/app/lib/expenseTravelLookup';
+import { formatUtcDate } from '@/app/lib/dateUtils';
 import LocationAccommodationsManager from '../../../../components/LocationAccommodationsManager';
 import AccommodationDisplay from '../../../../../components/AccommodationDisplay';
 import LinkedExpensesDisplay from '../../../../components/LinkedExpensesDisplay';
@@ -20,6 +21,8 @@ interface LocationItemProps {
   onLocationDelete: () => void;
   onViewPosts: () => void;
   onGeocode: (locationName: string) => Promise<[number, number]>;
+  isCollapsed: boolean;
+  onToggleCollapse: (isOpen: boolean) => void;
 }
 
 export default function LocationItem({
@@ -31,89 +34,125 @@ export default function LocationItem({
   onLocationDelete,
   onViewPosts,
   onGeocode,
+  isCollapsed,
+  onToggleCollapse,
 }: LocationItemProps) {
   const handleAccommodationIdsChange = (newIds: string[]) => {
     const updatedLocation = { ...location, accommodationIds: newIds };
     onLocationUpdate(updatedLocation);
   };
 
+  const formatDate = (date: string | Date) =>
+    formatUtcDate(date, 'en-GB', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric'
+    });
+
+  const getDateRangeLabel = () => {
+    if (location.endDate) {
+      return `${formatDate(location.date)} - ${formatDate(location.endDate)}`;
+    }
+
+    return formatDate(location.date);
+  };
+
   return (
-    <div className="border border-gray-200 dark:border-gray-600 rounded-lg p-4 bg-white dark:bg-gray-800 hover:shadow-md transition-shadow">
-      <InPlaceEditor<Location>
-        data={location}
-        onSave={async (updatedLocation) => {
-          onLocationUpdate(updatedLocation);
-        }}
-        editor={(location, onSave, onCancel) => (
-          <LocationInlineEditor
-            location={location}
-            onSave={onSave}
-            onCancel={onCancel}
-            onGeocode={async (locationName) => {
-              const coords = await onGeocode(locationName);
-              return coords;
+    <details
+      open={!isCollapsed}
+      onToggle={(event) => onToggleCollapse(event.currentTarget.open)}
+      className="border border-gray-200 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 shadow-sm hover:shadow-md transition-shadow"
+    >
+      <summary className="flex items-center gap-3 cursor-pointer px-4 py-3 select-none [&::-webkit-details-marker]:hidden">
+        <span
+          aria-hidden="true"
+          className={`text-gray-500 transition-transform ${isCollapsed ? '' : 'rotate-90'}`}
+        >
+          ▶
+        </span>
+        <div className="flex-1 text-left">
+          <div className="font-semibold text-gray-900 dark:text-white">{location.name}</div>
+          <div className="text-sm text-gray-500 dark:text-gray-400">{getDateRangeLabel()}</div>
+        </div>
+      </summary>
+
+      {!isCollapsed && (
+        <div className="border-t border-gray-200 dark:border-gray-700 px-4 pb-4 pt-4">
+          <InPlaceEditor<Location>
+            data={location}
+            onSave={async (updatedLocation) => {
+              onLocationUpdate(updatedLocation);
             }}
-            tripId={tripId}
-            travelLookup={travelLookup}
-            costData={costData}
-          />
-        )}
-      >
-        {(location, _isEditing, onEdit) => (
-          <div>
-            <LocationDisplay
-              location={location}
-              onEdit={onEdit}
-              onDelete={onLocationDelete}
-              onViewPosts={onViewPosts}
-              showAccommodations={false}
-              linkedExpenses={[]}
-              tripId={tripId}
-            />
-            
-            {/* Accommodation Display */}
-            {/* Show accommodations using the new system if available, otherwise fallback to legacy */}
-            {location.accommodationIds && location.accommodationIds.length > 0 ? (
-              <div className="mt-3">
-                <LocationAccommodationsManager
-                  tripId={tripId}
-                  locationId={location.id}
-                  locationName={location.name}
-                  accommodationIds={location.accommodationIds}
-                  onAccommodationIdsChange={handleAccommodationIdsChange}
-                  travelLookup={travelLookup}
-                  costData={costData}
-                  displayMode={true} // Read-only display mode
-                />
-              </div>
-            ) : location.accommodationData && (
-              <div className="mt-3">
-                <AccommodationDisplay
-                  accommodationData={location.accommodationData}
-                  isAccommodationPublic={location.isAccommodationPublic}
-                  privacyOptions={{ isAdminView: true }}
-                  className="text-sm"
-                  travelLookup={travelLookup}
-                  costData={costData}
-                />
-              </div>
-            )}
-            
-            {/* Linked Expenses Display */}
-            {travelLookup && costData && (
-              <LinkedExpensesDisplay
-                items={[
-                  { itemType: 'location', itemId: location.id },
-                  ...((location.accommodationIds || []).map((accId: string) => ({ itemType: 'accommodation', itemId: accId })) as { itemType: 'accommodation', itemId: string }[])
-                ]}
+            editor={(location, onSave, onCancel) => (
+              <LocationInlineEditor
+                location={location}
+                onSave={onSave}
+                onCancel={onCancel}
+                onGeocode={async (locationName) => {
+                  const coords = await onGeocode(locationName);
+                  return coords;
+                }}
+                tripId={tripId}
                 travelLookup={travelLookup}
                 costData={costData}
-                tripId={tripId}
               />
             )}
-          </div>
-        )}
-      </InPlaceEditor>
-    </div>
+          >
+            {(location, _isEditing, onEdit) => (
+              <div className="space-y-3">
+                <LocationDisplay
+                  location={location}
+                  onEdit={onEdit}
+                  onDelete={onLocationDelete}
+                  onViewPosts={onViewPosts}
+                  showAccommodations={false}
+                  linkedExpenses={[]}
+                  tripId={tripId}
+                  frameless
+                  showHeader={false}
+                />
+
+                {/* Accommodation Display */}
+                {/* Show accommodations using the new system if available, otherwise fallback to legacy */}
+                {location.accommodationIds && location.accommodationIds.length > 0 ? (
+                  <LocationAccommodationsManager
+                    tripId={tripId}
+                    locationId={location.id}
+                    locationName={location.name}
+                    accommodationIds={location.accommodationIds}
+                    onAccommodationIdsChange={handleAccommodationIdsChange}
+                    travelLookup={travelLookup}
+                    costData={costData}
+                    displayMode={true} // Read-only display mode
+                  />
+                ) : location.accommodationData && (
+                  <AccommodationDisplay
+                    accommodationData={location.accommodationData}
+                    isAccommodationPublic={location.isAccommodationPublic}
+                    privacyOptions={{ isAdminView: true }}
+                    className="text-sm"
+                    travelLookup={travelLookup}
+                    costData={costData}
+                  />
+                )}
+
+                {/* Linked Expenses Display */}
+                {travelLookup && costData && (
+                  <LinkedExpensesDisplay
+                    items={[
+                      { itemType: 'location', itemId: location.id },
+                      ...((location.accommodationIds || []).map((accId: string) => ({ itemType: 'accommodation', itemId: accId })) as { itemType: 'accommodation', itemId: string }[])
+                    ]}
+                    travelLookup={travelLookup}
+                    costData={costData}
+                    tripId={tripId}
+                  />
+                )}
+              </div>
+            )}
+          </InPlaceEditor>
+        </div>
+      )}
+    </details>
   );
 }


### PR DESCRIPTION
## Summary
- auto-collapse past trip locations in the admin editor while keeping current and future stops expanded
- add collapsible panels with summary headers and adjust location display to support frameless rendering

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69124f843a308333899c556feeb761c2)