### PR TITLE
Include cost tracker expenses when hydrating travel lookup

### DIFF
--- a/src/app/admin/components/CostTracking/CostTrackerEditor.tsx
+++ b/src/app/admin/components/CostTracking/CostTrackerEditor.tsx
@@ -137,7 +137,10 @@ export default function CostTrackerEditor({
           title: tripData.title,
           locations: tripData.locations,
           accommodations: tripData.accommodations,
-          routes: tripData.routes
+          routes: tripData.routes,
+          costData: {
+            expenses: costData.expenses
+          }
         });
         setTravelLookup(lookup);
       } else {
@@ -161,6 +164,12 @@ export default function CostTrackerEditor({
       setCostSummary(summary);
     }
   }, [costData]);
+
+  useEffect(() => {
+    if (travelLookup) {
+      travelLookup.hydrateFromExpenses(costData.expenses);
+    }
+  }, [costData.expenses, travelLookup]);
 
   const handleExpenseAdded = async (incomingExpense: Expense, travelLinkInfo?: TravelLinkInfo) => {
     let expense: Expense = { ...incomingExpense };

--- a/src/app/admin/components/CostTracking/ExpenseManager.tsx
+++ b/src/app/admin/components/CostTracking/ExpenseManager.tsx
@@ -107,15 +107,18 @@ export default function ExpenseManager({
     }
 
     return sortedExpenses.filter(expense => {
-      if (travelLookup) {
-        return !travelLookup.getTravelLinkForExpense(expense.id);
-      }
-
-      return !expense.travelReference;
+      const travelLink = travelLookup?.getTravelLinkForExpense(expense.id);
+      return !(travelLink || expense.travelReference);
     });
   }, [costData.expenses, showUnlinkedOnly, travelLookup]);
 
   const totalExpensesCount = costData.expenses.length;
+
+  useEffect(() => {
+    if (travelLookup) {
+      travelLookup.hydrateFromExpenses(costData.expenses);
+    }
+  }, [costData.expenses, travelLookup]);
 
   useEffect(() => {
     if (!isBulkLinkMode) {

--- a/src/app/admin/edit/[tripId]/hooks/useTripEditor.ts
+++ b/src/app/admin/edit/[tripId]/hooks/useTripEditor.ts
@@ -231,7 +231,10 @@ export function useTripEditor(tripId: string | null) {
             title: tripData.title,
             locations: tripData.locations,
             accommodations: accommodations,
-            routes: transportationRoutes
+            routes: transportationRoutes,
+            costData: {
+              expenses: costData.expenses
+            }
           });
           setTravelLookup(lookup);
         } else {

--- a/src/app/admin/shadow-planner/[tripId]/hooks/useShadowTripEditor.ts
+++ b/src/app/admin/shadow-planner/[tripId]/hooks/useShadowTripEditor.ts
@@ -228,7 +228,10 @@ export function useShadowTripEditor(tripId: string) {
                 type: route.transportType,
                 departureTime: route.date?.toISOString(),
                 privateNotes: route.privateNotes
-              }))
+              })),
+              costData: {
+                expenses: costData.expenses
+              }
             };
             const lookup = new ExpenseTravelLookup(tripId, tripData);
             setTravelLookup(lookup);


### PR DESCRIPTION
## Summary
- feed cost tracker expenses into `ExpenseTravelLookup` and add hydration support for legacy `travelReference` links
- pass cost tracker expenses to every lookup instantiation and refresh the map when expenses change so filters stay accurate
- extend lookup tests to cover expenses that only store `travelReference` data

## Testing
- npx jest src/app/__tests__/lib/expenseTravelLookup.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912514acf9c8333acb4dbca5567ceb2)