### PR TITLE
Add active trip days completed indicator to cost summary

### DIFF
--- a/src/app/admin/components/CostTracking/CostSummaryDashboard.tsx
+++ b/src/app/admin/components/CostTracking/CostSummaryDashboard.tsx
@@ -171,6 +171,12 @@ export default function CostSummaryDashboard({
               }
             })()}
           </p>
+          {costSummary.tripStatus === 'during' && costSummary.daysCompleted > 0 && (
+            <div className="mt-2 inline-flex items-center gap-2 rounded-full bg-orange-100 px-3 py-1 text-xs font-semibold text-orange-800 dark:bg-orange-900/40 dark:text-orange-100">
+              <span className="h-2 w-2 rounded-full bg-orange-500" aria-hidden="true" />
+              {costSummary.daysCompleted} day{costSummary.daysCompleted === 1 ? '' : 's'} completed
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -258,6 +258,7 @@ export type CostSummary = {
   remainingBudget: number;
   totalDays: number;
   remainingDays: number;
+  daysCompleted: number;
   averageSpentPerDay: number;
   suggestedDailyBudget: number;
   dailyBudgetBasisDays: number;


### PR DESCRIPTION
## Summary
- calculate and expose completed trip days in the cost summary data
- display a chip for completed days alongside the active trip countdown

## Testing
- npm run test:unit -- --runTestsByPath src/app/__tests__/utils.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693700c61a84833392fe9a02e8f58bfb)