### PR TITLE
Ignore pending YNAB shadows for duplicate detection

### DIFF
--- a/src/app/admin/components/YnabImportForm.tsx
+++ b/src/app/admin/components/YnabImportForm.tsx
@@ -86,7 +86,9 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
   };
 
   const normalizedExistingExpenses = useMemo<NormalizedExpense[]>(() => {
-    const expenses: Expense[] = costData.expenses || [];
+    const expenses: Expense[] = (costData.expenses || []).filter(
+      expense => !expense.isPendingYnabImport
+    );
 
     return expenses
       .map((expense) => {
@@ -571,6 +573,7 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
       if (importMethod === 'api') {
         // API-based import: send transactions directly to cost tracking API
         const updatedPayeeCategoryDefaults = { ...payeeCategoryDefaults };
+        const existingExpenses = (costData.expenses || []).filter(expense => !expense.isPendingYnabImport);
         const expensesToAdd = selectedTransactions.map(selection => {
           const transaction = processedTransactions.find(t => t.hash === selection.transactionHash);
           if (!transaction) throw new Error(`Transaction not found: ${selection.transactionHash}`);
@@ -606,7 +609,7 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            expenses: [...(costData.expenses || []), ...expensesToAdd],
+            expenses: [...existingExpenses, ...expensesToAdd],
             ynabImportData: {
               ...costData.ynabImportData,
               mappings: categoryMappings,
@@ -617,7 +620,9 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
             ynabConfig: {
               ...costData.ynabConfig,
               lastTransactionImport: new Date(),
-              transactionServerKnowledge: lastServerKnowledge
+              transactionServerKnowledge: lastServerKnowledge,
+              lastAutomaticTransactionSync: new Date(),
+              automaticTransactionServerKnowledge: lastServerKnowledge
             }
           }),
         });

--- a/src/app/api/cost-tracking/[id]/ynab-process/route.ts
+++ b/src/app/api/cost-tracking/[id]/ynab-process/route.ts
@@ -302,6 +302,9 @@ async function handleImportTransactions(
     importedTransactions.push(processedTxn);
   }
 
+  // Remove any pending YNAB shadow transactions before importing new ones
+  costData.expenses = costData.expenses.filter(expense => !expense.isPendingYnabImport);
+
   // Add new expenses to cost data
   costData.expenses.push(...newExpenses);
   costData.ynabImportData.importedTransactionHashes.push(...newHashes);
@@ -322,6 +325,13 @@ async function handleImportTransactions(
     countryBudgets: costData.countryBudgets,
     expenses: costData.expenses,
     ynabImportData: costData.ynabImportData,
+    ynabConfig: costData.ynabConfig
+      ? {
+          ...costData.ynabConfig,
+          lastTransactionImport: new Date(),
+          lastAutomaticTransactionSync: new Date()
+        }
+      : undefined,
     tripTitle: unifiedTrip.title,
     tripStartDate: unifiedTrip.startDate,
     tripEndDate: unifiedTrip.endDate,

--- a/src/app/lib/ynabPendingSync.ts
+++ b/src/app/lib/ynabPendingSync.ts
@@ -1,0 +1,146 @@
+import { YnabApiClient, ynabUtils } from './ynabApiClient';
+import { updateCostData } from './unifiedDataService';
+import { UnifiedTripData } from './dataMigration';
+import { Expense, YnabApiTransaction, YnabConfig } from '../types';
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+function shouldSkipSync(ynabConfig?: YnabConfig): boolean {
+  if (!ynabConfig?.apiKey || !ynabConfig?.selectedBudgetId) return true;
+  if (!ynabConfig.lastTransactionImport && !ynabConfig.lastTransactionSync) return true;
+
+  if (!ynabConfig.lastAutomaticTransactionSync) return false;
+
+  const lastSyncTime = new Date(ynabConfig.lastAutomaticTransactionSync).getTime();
+  return Date.now() - lastSyncTime < ONE_HOUR_MS;
+}
+
+function buildSinceDate(ynabConfig: YnabConfig): string | undefined {
+  const baselineDate =
+    ynabConfig.lastAutomaticTransactionSync ||
+    ynabConfig.lastTransactionImport ||
+    ynabConfig.lastTransactionSync;
+
+  if (!baselineDate) return undefined;
+  return ynabUtils.formatDate(new Date(baselineDate));
+}
+
+function buildServerKnowledge(ynabConfig: YnabConfig): number | undefined {
+  return ynabConfig.automaticTransactionServerKnowledge ?? ynabConfig.transactionServerKnowledge;
+}
+
+function hasDuplicate(expense: Expense, existing: Expense[]): boolean {
+  return existing.some(existingExpense =>
+    existingExpense.ynabTransactionId === expense.ynabTransactionId ||
+    (expense.ynabImportId && existingExpense.ynabImportId === expense.ynabImportId) ||
+    (expense.hash && existingExpense.hash === expense.hash)
+  );
+}
+
+function mapTransactionToExpense(
+  txn: YnabApiTransaction,
+  currency: string,
+  mapping: { countryName?: string; mappingType?: 'country' | 'general' | 'none' }
+): Expense {
+  const isOutflow = txn.amount < 0;
+  const absoluteAmount = Math.abs(ynabUtils.milliunitsToAmount(txn.amount));
+  const amount = isOutflow ? absoluteAmount : -absoluteAmount;
+
+  const isGeneralExpense = mapping.mappingType === 'general';
+  const country = isGeneralExpense ? 'General' : mapping.countryName || 'Unassigned';
+
+  return {
+    id: Date.now().toString(36) + Math.random().toString(36).substring(2),
+    date: new Date(txn.date),
+    amount,
+    currency,
+    category: 'Pending Import',
+    country,
+    description: txn.payee_name || 'Unknown Payee',
+    notes: txn.memo || '',
+    isGeneralExpense,
+    isPendingYnabImport: true,
+    expenseType: 'actual',
+    source: 'ynab-api-pending',
+    hash: ynabUtils.generateTransactionHash(txn),
+    ynabTransactionId: txn.id,
+    ynabImportId: txn.import_id
+  };
+}
+
+export async function maybeSyncPendingYnabTransactions(
+  costTrackerId: string,
+  unifiedTrip: UnifiedTripData
+): Promise<UnifiedTripData | null> {
+  const costData = unifiedTrip.costData;
+  if (!costData || !costData.ynabConfig || shouldSkipSync(costData.ynabConfig)) {
+    return null;
+  }
+
+  const mappedCategories = costData.ynabImportData?.mappings
+    ?.filter(mapping => mapping.mappingType !== 'none' && mapping.ynabCategoryId)
+    .map(mapping => mapping.ynabCategoryId!) || [];
+
+  if (mappedCategories.length === 0) {
+    return null;
+  }
+
+  const sinceDate = buildSinceDate(costData.ynabConfig);
+  const serverKnowledge = buildServerKnowledge(costData.ynabConfig);
+
+  const client = new YnabApiClient(costData.ynabConfig.apiKey);
+  let transactionResult: { transactions: YnabApiTransaction[]; serverKnowledge: number };
+
+  try {
+    transactionResult = await client.getTransactionsByCategories(
+      costData.ynabConfig.selectedBudgetId,
+      mappedCategories,
+      sinceDate,
+      serverKnowledge
+    );
+  } catch (error) {
+    console.error('YNAB hourly sync failed:', error);
+    return null;
+  }
+
+  const mappingLookup = new Map(
+    (costData.ynabImportData?.mappings || [])
+      .filter(mapping => mapping.ynabCategoryId)
+      .map(mapping => [mapping.ynabCategoryId!, mapping])
+  );
+
+  const existingExpenses = costData.expenses || [];
+  const pendingExpenses: Expense[] = [];
+
+  for (const txn of transactionResult.transactions) {
+    const mapping = txn.category_id ? mappingLookup.get(txn.category_id) : undefined;
+    const expense = mapTransactionToExpense(txn, costData.currency, mapping || {});
+
+    if (!hasDuplicate(expense, [...existingExpenses, ...pendingExpenses])) {
+      pendingExpenses.push(expense);
+    }
+  }
+
+  const updatedExpenses = [...existingExpenses, ...pendingExpenses];
+
+  const updatedUnifiedData = await updateCostData(costTrackerId, {
+    overallBudget: costData.overallBudget,
+    currency: costData.currency,
+    countryBudgets: costData.countryBudgets,
+    expenses: updatedExpenses,
+    ynabImportData: costData.ynabImportData,
+    ynabConfig: {
+      ...costData.ynabConfig,
+      lastAutomaticTransactionSync: new Date(),
+      automaticTransactionServerKnowledge: transactionResult.serverKnowledge
+    },
+    tripTitle: unifiedTrip.title,
+    tripStartDate: unifiedTrip.startDate,
+    tripEndDate: unifiedTrip.endDate,
+    ...(costData.customCategories ? { customCategories: costData.customCategories } : {}),
+    createdAt: unifiedTrip.createdAt,
+    updatedAt: new Date().toISOString()
+  });
+
+  return updatedUnifiedData;
+}

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -227,6 +227,7 @@ export type Expense = {
   description: string;
   notes?: string;
   isGeneralExpense?: boolean; // For expenses not tied to a specific country
+  isPendingYnabImport?: boolean; // For shadow expenses created by hourly YNAB syncs
   expenseType: ExpenseType; // Type of expense for different budget calculations
   originalPlannedId?: string; // For linking actual expenses to original planned expenses
   // Travel integration (private)
@@ -362,6 +363,8 @@ export interface YnabConfig {
   lastTransactionSync?: Date;
   lastTransactionImport?: Date;
   transactionServerKnowledge?: number;
+  lastAutomaticTransactionSync?: Date;
+  automaticTransactionServerKnowledge?: number;
 }
 
 // YNAB API Budget from SDK


### PR DESCRIPTION
## Summary
- exclude pending YNAB shadow expenses from duplicate detection during manual imports so they no longer conflict with real transactions

## Testing
- NO_COLOR=1 bun run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693999994b908333a8394784244f3b7e)