### PR TITLE
Add manual Wikipedia override for locations

### DIFF
--- a/src/app/admin/components/LocationForm.tsx
+++ b/src/app/admin/components/LocationForm.tsx
@@ -62,6 +62,8 @@ export default function LocationForm({
       Math.ceil((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1 : 
       undefined;
     
+    const wikipediaRef = typeof data.wikipediaRef === 'string' ? data.wikipediaRef.trim() : '';
+
     // Create location object
     const location: Location = {
       id: editingLocationIndex !== null ? currentLocation.id! : generateId(),
@@ -81,7 +83,8 @@ export default function LocationForm({
       // Backward compatibility
       accommodationData: currentLocation.accommodationData,
       isAccommodationPublic: currentLocation.isAccommodationPublic || false,
-      costTrackingLinks: currentLocation.costTrackingLinks || []
+      costTrackingLinks: currentLocation.costTrackingLinks || [],
+      wikipediaRef: wikipediaRef || undefined
     };
 
       // Validate required fields
@@ -107,7 +110,8 @@ export default function LocationForm({
         accommodationIds: [],
         accommodationData: '',
         isAccommodationPublic: false,
-        costTrackingLinks: []
+        costTrackingLinks: [],
+        wikipediaRef: ''
       });
       
       if (editingLocationIndex !== null) {
@@ -224,6 +228,24 @@ export default function LocationForm({
           />
         </div>
 
+        <div className="md:col-span-2">
+          <label htmlFor="location-wikipedia-ref" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
+            Wikipedia override (optional)
+          </label>
+          <input
+            id="location-wikipedia-ref"
+            name="wikipediaRef"
+            type="text"
+            defaultValue={currentLocation.wikipediaRef || ''}
+            onChange={(e) => setCurrentLocation((prev: Partial<Location>) => ({ ...prev, wikipediaRef: e.target.value }))}
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+            placeholder="e.g. Paris or Q90"
+          />
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            Leave blank to use automatic Wikipedia matching.
+          </p>
+        </div>
+
         <div>
           <label htmlFor="location-latitude" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">
             Coordinates
@@ -308,7 +330,8 @@ export default function LocationForm({
                   accommodationIds: [],
                   accommodationData: '',
                   isAccommodationPublic: false,
-                  costTrackingLinks: []
+                  costTrackingLinks: [],
+                  wikipediaRef: ''
                 });
               }}
               className="px-4 py-2 bg-gray-500 text-white rounded-md hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500"

--- a/src/app/admin/components/LocationInlineEditor.tsx
+++ b/src/app/admin/components/LocationInlineEditor.tsx
@@ -39,7 +39,11 @@ export default function LocationInlineEditor({
       return;
     }
 
-    onSave(formData);
+    const wikipediaRef = formData.wikipediaRef?.trim();
+    onSave({
+      ...formData,
+      wikipediaRef: wikipediaRef || undefined
+    });
   };
 
   const handleGeocoding = async () => {
@@ -170,6 +174,19 @@ export default function LocationInlineEditor({
             className="w-full px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
             rows={2}
             placeholder="What you did here..."
+          />
+        </div>
+
+        <div>
+          <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+            Wikipedia override
+          </label>
+          <input
+            type="text"
+            value={formData.wikipediaRef || ''}
+            onChange={(e) => setFormData(prev => ({ ...prev, wikipediaRef: e.target.value }))}
+            className="w-full px-2 py-1 text-sm border border-gray-300 dark:border-gray-600 rounded focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
+            placeholder="e.g. Paris or Q90 (leave blank for auto)"
           />
         </div>
 

--- a/src/app/map/[id]/components/EmbeddableMap.tsx
+++ b/src/app/map/[id]/components/EmbeddableMap.tsx
@@ -36,6 +36,7 @@ interface TravelData {
     date: string;
     endDate?: string;
     notes?: string;
+    wikipediaRef?: string;
     instagramPosts?: Array<{
       id: string;
       url: string;
@@ -467,7 +468,14 @@ const EmbeddableMap: React.FC<EmbeddableMapProps> = ({ travelData }) => {
       marker.bindPopup(initialPopupContent, { maxWidth: 400, className: 'wikipedia-popup' });
 
       try {
-        const response = await fetch(`/api/wikipedia/${encodeURIComponent(location.name)}?lat=${location.coordinates[0]}&lon=${location.coordinates[1]}`);
+        const wikipediaParams = new URLSearchParams({
+          lat: location.coordinates[0].toString(),
+          lon: location.coordinates[1].toString()
+        });
+        if (location.wikipediaRef?.trim()) {
+          wikipediaParams.set('wikipediaRef', location.wikipediaRef);
+        }
+        const response = await fetch(`/api/wikipedia/${encodeURIComponent(location.name)}?${wikipediaParams.toString()}`);
         if (response.ok) {
           const wikipediaResponse = await response.json();
           // Weather fetch (always today's weather at this location)


### PR DESCRIPTION
### Motivation
- Provide a way for admins to explicitly set which Wikipedia article should be used for a location to override the automatic matching logic.
- Preserve existing automatic selection when no override is provided so current behavior remains unchanged.
- Ensure embeddable maps and popups honor manual overrides when present.

### Description
- Add a `wikipediaRef` input to the location add/edit form (`LocationForm`) and the inline editor (`LocationInlineEditor`) and persist it on save using the existing `Location.wikipediaRef` field.
- Normalize blank overrides to `undefined` when saving so the existing automatic resolution is used when no override is set.
- Pass `wikipediaRef` as a query parameter to the embeddable map Wikipedia API request in `EmbeddableMap.tsx` so popups use the override when available.
- Small UI copy explaining that leaving the field blank will use automatic Wikipedia matching.

### Testing
- Ran unit tests with `bun run test:unit`, which exercised the test suite but reported failures in `AccessibleDatePicker` tests and a schema expectation in `src/app/__tests__/lib/dataMigration.test.ts` (the `CURRENT_SCHEMA_VERSION` expectation), so the unit run did not fully pass.
- Built the app with `bun run build`, which completed successfully and produced an optimized production build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948887a132883339cd598cd918b64bb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Wikipedia reference field for locations, editable across forms and inline editors.
  * Locations now support customizable Wikipedia reference metadata for enhanced data enrichment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->