### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/src/app/api/cost-tracking/[id]/ynab-process/route.ts
+++ b/src/app/api/cost-tracking/[id]/ynab-process/route.ts
@@ -28,6 +28,14 @@ function hasCustomCategories(obj: unknown): obj is { customCategories: string[] 
   );
 }
 
+function isValidTempFileId(tempFileId: unknown): tempFileId is string {
+  return (
+    typeof tempFileId === 'string' &&
+    tempFileId.length > 0 &&
+    /^[A-Za-z0-9_-]+$/.test(tempFileId)
+  );
+}
+
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     // Check if request is from admin domain
@@ -85,6 +93,13 @@ async function handleProcessTransactions(
     return NextResponse.json({ 
       error: 'Missing required data: tempFileId and mappings are required for processing' 
     }, { status: 400 });
+  }
+
+  if (!isValidTempFileId(tempFileId)) {
+    return NextResponse.json(
+      { error: 'Invalid tempFileId format' },
+      { status: 400 }
+    );
   }
 
   // Load the temporary file


### PR DESCRIPTION
Potential fix for [https://github.com/bdamokos/travel-tracker/security/code-scanning/14](https://github.com/bdamokos/travel-tracker/security/code-scanning/14)

To fix this, we should prevent `tempFileId` from being able to alter the target directory or escape `process.cwd()/data`. The safest general approaches are: (1) normalize and resolve the constructed path, then verify it is still inside an expected root directory, or (2) restrict `tempFileId` to a simple, safe filename pattern (for example, alphanumeric plus a few safe characters) and reject anything else. Since this ID is very likely a simple token, enforcing a strict pattern on `tempFileId` is straightforward and avoids surprises.

The best minimal fix here is:

1. Introduce a small validation helper for `tempFileId` in this file that:
   - Checks `tempFileId` is a non-empty string.
   - Ensures it matches a conservative regular expression such as `/^[A-Za-z0-9_-]+$/` (letters, digits, underscore, hyphen).
2. Use this helper in both `handleProcessTransactions` (shown) and, ideally, in `handleImportTransactions` as well if it uses `tempFileId` for file access. However, we are constrained to edit only the shown code; so we will at least validate in `handleProcessTransactions`.
3. If validation fails, return a 400 response with an explanatory error message instead of trying to read the file.
4. Optionally, we can add an extra containment check after `join` using `path.resolve` and comparing against the intended root directory, but with a strict filename pattern, `join(process.cwd(), 'data', ...)` is already safe from traversal.

Concretely, in `src/app/api/cost-tracking/[id]/ynab-process/route.ts`:

- Add a small utility function, e.g. `isValidTempFileId(tempFileId: unknown): tempFileId is string`, near the top of the file.
- In `handleProcessTransactions`, before building `tempFilePath`, call this helper and return a 400 if `tempFileId` is invalid.
- Optionally, to be extra robust, compute a `dataRoot = join(process.cwd(), 'data')` and then `tempFilePath = join(dataRoot, \`${tempFileId}.json\`)` and verify that `tempFilePath.startsWith(dataRoot + path.sep)` after `path.resolve`. This needs the already-imported `join` and possibly `resolve` (but we should avoid changing imports beyond the shown `join` if not necessary). Given the strict ID pattern, the additional check is not strictly required for safety.

No new external dependencies are needed; we can implement this with basic TypeScript and the existing `path` import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation of temporary file identifiers in cost tracking to prevent processing errors and provide appropriate error responses when invalid identifiers are encountered.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->