### PR TITLE
Potential fix for code scanning alert no. 18: Use of externally-controlled format string

### DIFF
--- a/src/app/api/cost-tracking/route.ts
+++ b/src/app/api/cost-tracking/route.ts
@@ -84,7 +84,7 @@ export async function GET(request: NextRequest) {
     // Validate trip boundaries
     const validation = validateAllTripBoundaries(costDataSource);
     if (!validation.isValid) {
-      console.warn(`Trip boundary violations detected in trip ${cleanId}:`, validation.errors);
+      console.warn('Trip boundary violations detected in trip %s:', cleanId, validation.errors);
       // Continue processing but log the violations
     }
     


### PR DESCRIPTION
Potential fix for [https://github.com/bdamokos/travel-tracker/security/code-scanning/18](https://github.com/bdamokos/travel-tracker/security/code-scanning/18)

In general, to fix externally-controlled format string issues with `console.log`, `console.warn`, or `util.format`, avoid using untrusted data inside the format string itself. Instead, keep the format string static and pass untrusted data as additional arguments (for example, use `"Trip %s"`, `id` rather than \`Trip ${id}\`), or concatenate using `+` or other safe mechanisms so the first argument to `console.*` does not contain attacker-controlled `%` sequences.

For this specific case in `src/app/api/cost-tracking/route.ts` at line 87, the best fix without changing observable functionality is to make the first argument to `console.warn` a static string (or at least not include `cleanId` in it), and pass `cleanId` and `validation.errors` as subsequent arguments. For example:

```ts
console.warn('Trip boundary violations detected in trip %s:', cleanId, validation.errors);
```

or, if you prefer to avoid `%` entirely:

```ts
console.warn('Trip boundary violations detected in trip', cleanId, ':', validation.errors);
```

Both approaches avoid untrusted data influencing the format string. No new imports or helper methods are required. The only change is on the `console.warn` call inside the `GET` handler; all other logic and returned data remain untouched.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal logging formatting for trip boundary violation detection to enhance system diagnostics and troubleshooting capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->