### PR TITLE
Update YnabImportForm tests for method selection step

### DIFF
--- a/src/app/admin/components/__tests__/YnabImportForm.test.tsx
+++ b/src/app/admin/components/__tests__/YnabImportForm.test.tsx
@@ -39,6 +39,11 @@ describe('YnabImportForm', () => {
     (global.fetch as jest.Mock).mockClear();
   });
 
+  const navigateToFileUploadStep = () => {
+    fireEvent.click(screen.getByText('Upload YNAB Export File'));
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+  };
+
   it('renders when isOpen is true', () => {
     render(
       <YnabImportForm
@@ -82,7 +87,7 @@ describe('YnabImportForm', () => {
     expect(mockOnClose).toHaveBeenCalledTimes(1);
   });
 
-  it('shows file upload interface in step 1', () => {
+  it('shows file upload interface after selecting file import method', async () => {
     render(
       <YnabImportForm
         isOpen={true}
@@ -92,8 +97,7 @@ describe('YnabImportForm', () => {
       />
     );
 
-    fireEvent.click(screen.getByText('Upload YNAB Export File'));
-    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    navigateToFileUploadStep();
 
     expect(screen.getByText('Choose TSV or ZIP File')).toBeInTheDocument();
     expect(screen.getByText(/Upload your YNAB export file/)).toBeInTheDocument();
@@ -128,8 +132,7 @@ describe('YnabImportForm', () => {
     // Initially should show method selection
     expect(screen.getByText('Choose Import Method')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText('Upload YNAB Export File'));
-    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    navigateToFileUploadStep();
 
     // After selecting file import, should show upload step
     expect(screen.getByText('Upload YNAB Export')).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- update YnabImportForm unit tests to expect the initial "Choose Import Method" step
- simulate selecting the file import path before asserting the upload UI content
- verify the modal title and progress indicator reflect the four-step flow

## Testing
- bun run test:unit -- src/app/admin/components/__tests__/YnabImportForm.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695013b8c1448333a25f0b7e35c48df6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added import method selection interface with options to upload YNAB export file or load from YNAB API.
  * Updated YNAB import workflow with new progress steps for improved user guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->