### PR TITLE
Keep cash refunds categorized as refunds

### DIFF
--- a/src/app/__tests__/unit/cashTransactions.test.ts
+++ b/src/app/__tests__/unit/cashTransactions.test.ts
@@ -7,7 +7,7 @@ import {
   createCashSourceExpense,
   restoreAllocationSegmentsOnSources
 } from '@/app/lib/cashTransactions';
-import { CASH_CATEGORY_NAME } from '@/app/lib/costUtils';
+import { CASH_CATEGORY_NAME, REFUNDS_CATEGORY_NAME } from '@/app/lib/costUtils';
 
 describe('cash transaction utilities', () => {
   const baseDate = new Date('2024-01-01T00:00:00Z');
@@ -49,7 +49,7 @@ describe('cash transaction utilities', () => {
     });
 
     expect(refund.amount).toBeCloseTo(-50, 5);
-    expect(refund.category).toBe(CASH_CATEGORY_NAME);
+    expect(refund.category).toBe(REFUNDS_CATEGORY_NAME);
     expect(refund.cashTransaction).toBeDefined();
     expect(refund.cashTransaction?.sourceType).toBe('refund');
     expect(refund.cashTransaction?.originalBaseAmount).toBeCloseTo(50, 5);


### PR DESCRIPTION
## Summary
- keep cash refund expenses in the refunds category
- align the cash transaction unit test expectations with the refunds categorization

## Testing
- bun run test:unit cashTransactions.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69501380dd3483338dd4646a06a25139)