### PR TITLE
Fix AccessibleDatePicker accessibility tests

### DIFF
--- a/src/app/admin/components/AccessibleDatePicker.tsx
+++ b/src/app/admin/components/AccessibleDatePicker.tsx
@@ -96,7 +96,7 @@ export default function AccessibleDatePicker({
   return (
     <OverlayProvider>
       <div className="relative">
-        <div {...groupProps} ref={groupRef} className="flex items-stretch">
+        <div {...groupProps} aria-required={required || undefined} ref={groupRef} className="flex items-stretch">
           <DateField
             {...fieldProps}
             id={id}


### PR DESCRIPTION
## Summary
- align AccessibleDatePicker tests with React Aria segmented spinbutton structure
- ensure aria-required is forwarded on the date picker group
- adjust focus and constraint tests for segment-based navigation

## Testing
- npm run test:unit -- src/app/admin/components/__tests__/AccessibleDatePicker.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950341ede8c833399d6218b8e16297a)