### PR TITLE
Refactor LinkedExpensesDisplay tests for SWR hooks

### DIFF
--- a/src/app/admin/components/__tests__/LinkedExpensesDisplay.test.tsx
+++ b/src/app/admin/components/__tests__/LinkedExpensesDisplay.test.tsx
@@ -168,6 +168,14 @@ describe('LinkedExpensesDisplay', () => {
   });
 
   it('should sort expenses by date', async () => {
+    // Provide expenses in unsorted order to verify the component's sorting logic
+    mockUseExpenses.mockReturnValue({
+      expenses: [mockExpenses[2], mockExpenses[0], mockExpenses[1]], // Unsorted: expense-3, expense-1, expense-2
+      isLoading: false,
+      isError: undefined,
+      mutate: jest.fn(),
+    });
+
     render(
       <LinkedExpensesDisplay
         itemId="location-1"


### PR DESCRIPTION
## Summary
- mock the expense hooks used by LinkedExpensesDisplay so the component receives expected data during tests
- update scenarios to reflect SWR-driven loading and no-data behaviors while keeping ordering assertions

## Testing
- npm run test:unit -- src/app/admin/components/__tests__/LinkedExpensesDisplay.test.tsx
- bun run build *(fails: existing ESLint warnings across unrelated files stop the build)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950346187f48333aa42bc7ed7bd707e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite for LinkedExpenses functionality with improved data setup and management
  * Enhanced test coverage for loading states and edge cases including data deduplication and sorting
  * Updated test assertions to ensure component behavior remains correct

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->