### PR TITLE
Align trip data isolation migration test with current schema

### DIFF
--- a/src/app/__tests__/integration/trip-data-isolation-comprehensive.integration.test.ts
+++ b/src/app/__tests__/integration/trip-data-isolation-comprehensive.integration.test.ts
@@ -372,7 +372,6 @@ describe('Trip Data Isolation - Comprehensive Integration Tests', () => {
 
             // Verify migration results
             expect(migratedData.schemaVersion).toBe(CURRENT_SCHEMA_VERSION);
-            expect(migratedData.schemaVersion).toBe(4);
 
             // Verify invalid links were removed from location
             const location = migratedData.travelData?.locations?.[0];


### PR DESCRIPTION
## Summary
- update the trip data isolation migration integration test to assert against the current schema version
- keep v3→v4 cleanup validations while allowing later migrations to advance schema beyond 4

## Testing
- JEST_INTEGRATION_TESTS=true bun run test:integration -- src/app/__tests__/integration/trip-data-isolation-comprehensive.integration.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695097f11c34833396dc3135a8fc91e5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated schema version validation in integration tests to use dynamic version checking instead of hard-coded values, improving test maintainability.
  * Minor formatting adjustments in test files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->