### PR TITLE
Precompute map enrichments on startup and every 24 hours (weather & Wikipedia)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import ErrorBoundary from './components/ErrorBoundary';
-import { ensureMapDataPreloaderRunning } from './lib/mapDataPreloader';
+import { ensureMapDataPreloaderRunning } from '@/app/lib/mapDataPreloader';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -12,13 +12,13 @@ export const metadata: Metadata = {
   manifest: '/manifest.json',
 };
 
-ensureMapDataPreloaderRunning();
-
 export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  ensureMapDataPreloaderRunning();
+
   return (
     <html lang="en">
       <head>


### PR DESCRIPTION
### Motivation
- Ensure map markers show prepopulated city descriptions and weather so users see content immediately when opening popups. 
- Avoid changing existing cache invalidation semantics by reusing the same service entry points used by on-demand website requests. 
- Run the precomputation on the server to avoid client-side overhead and to make results available to all viewers. 

### Description
- Add a server-only preloader `src/app/lib/mapDataPreloader.ts` that enumerates stored trips and normalizes/deduplicates location targets for enrichment. 
- For each unique target it calls the existing `wikipediaService.getLocationData` and `weatherService.getWeatherForLocation`, avoiding custom cache logic so service-level invalidation remains unchanged. 
- Wire the preloader to app startup via `ensureMapDataPreloaderRunning()` from `src/app/layout.tsx` and schedule reruns every 24 hours, with opt-out via `DISABLE_MAP_PREFETCH` and no-op in test environment. 
- Skip invalid locations (bad coordinates or date ranges) and deduplicate using generated Wikipedia filenames and a weather-range key to minimize redundant fetches. 

### Testing
- Ran unit tests with `TEST_DATA_DIR=/workspace/travel-tracker/.tmp/test-data bun run test:unit`. 
- All unit test suites passed (`23` suites, `270` tests) after creating the test data directory used by backup tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d9e0524e48333afb7b8f492a911b2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background data preloading enhances map performance and accelerates location data retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->