### PR TITLE
Show Wikipedia override link in trip editor location cards

### DIFF
--- a/src/app/admin/components/LocationDisplay.tsx
+++ b/src/app/admin/components/LocationDisplay.tsx
@@ -7,7 +7,7 @@ import { useExpenseLinksForTravelItem } from '@/app/hooks/useExpenseLinks';
 import { useExpenses } from '@/app/hooks/useExpenses';
 import { formatUtcDate } from '@/app/lib/dateUtils';
 import TikTokIcon from '@/app/components/icons/TikTokIcon';
-import { parseWikipediaReference } from '@/app/lib/wikipediaUtils';
+import { buildWikipediaReferenceUrl, parseWikipediaReference } from '@/app/lib/wikipediaUtils';
 
 interface LocationDisplayProps {
   location: Location;
@@ -63,11 +63,7 @@ export default function LocationDisplay({
   const hasCoords = location.coordinates[0] !== 0 || location.coordinates[1] !== 0;
   const wikipediaRef = location.wikipediaRef?.trim();
   const parsedWikipediaRef = parseWikipediaReference(wikipediaRef);
-  const wikipediaLink = parsedWikipediaRef.isValid
-    ? parsedWikipediaRef.type === 'wikidata'
-      ? `https://www.wikidata.org/wiki/${parsedWikipediaRef.value}`
-      : `https://en.wikipedia.org/wiki/${encodeURIComponent(parsedWikipediaRef.value ?? '').replace(/%20/g, '_')}`
-    : null;
+  const wikipediaLink = buildWikipediaReferenceUrl(parsedWikipediaRef);
 
   const containerClassName = [
     frameless
@@ -156,7 +152,7 @@ export default function LocationDisplay({
             <a
               href={wikipediaLink}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline"
             >
               {parsedWikipediaRef.type === 'wikidata'

--- a/src/app/lib/wikipediaUtils.ts
+++ b/src/app/lib/wikipediaUtils.ts
@@ -246,3 +246,22 @@ export function parseWikipediaReference(wikipediaRef?: string): {
 
   return { type: null, value: null, isValid: false };
 }
+
+/**
+ * Build a canonical URL for a parsed Wikipedia reference.
+ */
+export function buildWikipediaReferenceUrl(reference: {
+  type: 'article' | 'wikidata' | null;
+  value: string | null;
+  isValid: boolean;
+}): string | null {
+  if (!reference.isValid || !reference.value) {
+    return null;
+  }
+
+  if (reference.type === 'wikidata') {
+    return `https://www.wikidata.org/wiki/${reference.value}`;
+  }
+
+  return `https://en.wikipedia.org/wiki/${encodeURIComponent(reference.value).replace(/%20/g, '_')}`;
+}


### PR DESCRIPTION
### Motivation
- The trip editor should surface a custom Wikipedia/Wikidata page set on a location so editors can see the resolved link without opening the inline editor.
- Previously the custom `wikipediaRef` was only visible inside the inline edit form and not on the location display card.

### Description
- Added parsing of `location.wikipediaRef` using `parseWikipediaReference` and resolve either a Wikipedia or Wikidata URL.
- Render a "Wikipedia override" link in the location details area of the trip editor when a valid override is present.
- Implemented the change in `src/app/admin/components/LocationDisplay.tsx` and imported `parseWikipediaReference` from `src/app/lib/wikipediaUtils.ts`.

### Testing
- Ran unit tests with `bun run test:unit` and all tests passed (273 passed).
- Built the app with `bun run build` and the production build completed successfully (build emits existing lint warnings but succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da6d9c04083339aeeb1a480750fe9)