### PR TITLE
Add sample map data seeding instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,9 +32,15 @@
 # Sample map data for a freshly set up server
 Use the same trip/location/route payloads as the integration test in `src/app/__tests__/integration/map-functionality.test.ts` to seed a server with realistic map data. The workflow mirrors the test pyramid (create trip → add locations → add route points).
 
-1. Start the app (admin or embed is fine) and note the API base URL:
+1. Start the app (admin or embed is fine) and export the variables used below:
    - Local dev: `http://localhost:3000`
    - Docker embed service: `http://localhost:3002`
+   ```bash
+   export BASE_URL="http://localhost:3000"
+   export TRIP_ID=""
+   export COST_ID=""
+   ```
+   - Update `BASE_URL` if you are using the docker embed service.
 2. Create a trip:
    ```bash
    curl -X POST "$BASE_URL/api/travel-data" \
@@ -48,7 +54,10 @@ Use the same trip/location/route payloads as the integration test in `src/app/__
        "routes": []
      }'
    ```
-   - Capture the `id` from the response; it is needed for subsequent calls.
+   - Capture the `id` from the response and export it for subsequent calls:
+     ```bash
+     export TRIP_ID="...response id..."
+     ```
 3. Add two locations (London + Paris) using the same coordinates as the integration test:
    ```bash
    curl -X PUT "$BASE_URL/api/travel-data?id=$TRIP_ID" \
@@ -126,6 +135,48 @@ Use the same trip/location/route payloads as the integration test in `src/app/__
    ```bash
    curl "$BASE_URL/api/travel-data?id=$TRIP_ID"
    ```
+6. Initialize cost tracking data (based on `src/app/__tests__/integration/cost-tracking-api.integration.test.ts`):
+   ```bash
+   curl -X POST "$BASE_URL/api/cost-tracking" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "tripId": "'"$TRIP_ID"'",
+       "tripTitle": "Sample Map Trip Costs",
+       "tripStartDate": "2024-07-01T00:00:00.000Z",
+       "tripEndDate": "2024-07-15T00:00:00.000Z",
+       "overallBudget": 2500,
+       "currency": "EUR",
+       "countryBudgets": [
+         {
+           "id": "budget-france",
+           "country": "France",
+           "amount": 1200,
+           "currency": "EUR",
+           "notes": "France portion of trip"
+         }
+       ],
+       "expenses": [
+         {
+           "id": "expense-test-1",
+           "date": "2024-07-02T00:00:00.000Z",
+           "amount": 150,
+           "currency": "EUR",
+           "category": "Accommodation",
+           "country": "France",
+           "description": "Hotel night 1",
+           "expenseType": "actual"
+         }
+       ]
+     }'
+   ```
+   - Capture the `id` from the response and export it:
+     ```bash
+     export COST_ID="...response id..."
+     ```
+7. Generate additional data by analogy to the integration tests:
+   - Accommodations and linked travel items: see `src/app/__tests__/integration/travel-data-update-links-validation.integration.test.ts` for the payload shape and the `accommodations` array.
+   - Social content fields (Instagram/blog posts): see `src/app/__tests__/integration/debug-frontend-flow.integration.test.ts` for `instagramPosts`, `blogPosts`, and `accommodationData` examples in the travel data payload.
+   - The same API endpoints (`/api/travel-data` and `/api/cost-tracking`) accept expanded payloads, so you can extend the JSON bodies above with those fields as needed.
 
 # Tests
 


### PR DESCRIPTION
### Motivation
- Provide a simple, repeatable way to seed a fresh server with realistic map data for manual testing and development.
- Reuse the same payloads and workflow used by the `map-functionality` integration test to ensure parity between test data and manual seed data.
- Make it easy to verify map rendering and route point behavior without relying on the external routing API.

### Description
- Added a new section in `AGENTS.md` titled "Sample map data for a freshly set up server" with step-by-step `curl` examples to create a trip, add two locations, and add a route with `routePoints`.
- The instructions reference the integration test payloads in `src/app/__tests__/integration/map-functionality.test.ts` and include an example three-point `routePoints` fallback for mocked routing.
- Examples show how to POST a trip, PUT updated trip data (`locations`/`routes`), and GET the trip via the `api/travel-data` endpoint.

### Testing
- Ran `bun run build`, which completed successfully (production build generated and pages were prerendered).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da9aeb1b083338197f7db6a94f0e3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation with additional workflow examples for map data operations, including practical API usage guidance and verification steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->