### PR TITLE
Align app import aliases

### DIFF
--- a/src/app/__tests__/integration/map-functionality.test.ts
+++ b/src/app/__tests__/integration/map-functionality.test.ts
@@ -354,7 +354,7 @@ describe('Map Functionality Integration Tests (Pyramid)', () => {
       
       if (await isExternalApiAvailable()) {
         // Use real API
-        const { generateRoutePoints } = await import('../../lib/routeUtils')
+        const { generateRoutePoints } = await import('@/app/lib/routeUtils')
         routePoints = await generateRoutePoints(transportation)
         console.log(`✅ Test 3: Generated ${routePoints.length} RoutePoints via external API`)
       } else {
@@ -456,7 +456,7 @@ describe('Map Functionality Integration Tests (Pyramid)', () => {
       
       if (await isExternalApiAvailable()) {
         // Import and use real route generation function
-        const { generateRoutePoints } = await import('../../lib/routeUtils')
+        const { generateRoutePoints } = await import('@/app/lib/routeUtils')
         routePoints = await generateRoutePoints(transportation)
         console.log(`✅ Test 3: Direct route generation via external API - ${routePoints.length} points`)
       } else {
@@ -526,7 +526,7 @@ describe('Map Functionality Integration Tests (Pyramid)', () => {
         toCoordinates: TEST_ROUTE.toCoords
       }
       
-      const { generateRoutePoints } = await import('../../lib/routeUtils')
+      const { generateRoutePoints } = await import('@/app/lib/routeUtils')
       const routePoints = await generateRoutePoints(routeData)
       const routeWithPoints = { ...routeData, routePoints }
       

--- a/src/app/__tests__/utils/mockRouteUtils.ts
+++ b/src/app/__tests__/utils/mockRouteUtils.ts
@@ -154,8 +154,8 @@ export const setupRouteMocking = () => {
   });
   
   // Mock the route utils module
-  jest.doMock('../../lib/routeUtils', () => ({
-    ...jest.requireActual('../../lib/routeUtils'),
+  jest.doMock('@/app/lib/routeUtils', () => ({
+    ...jest.requireActual('@/app/lib/routeUtils'),
     generateRoutePoints: mockGenerateRoutePoints
   }));
   

--- a/src/app/admin/components/LocationInlineEditor.tsx
+++ b/src/app/admin/components/LocationInlineEditor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import AccessibleDatePicker from './AccessibleDatePicker';
+import AccessibleDatePicker from '@/app/admin/components/AccessibleDatePicker';
 import CostTrackingLinksManager from '@/app/admin/components/CostTrackingLinksManager';
 import LocationAccommodationsManager from '@/app/admin/components/LocationAccommodationsManager';
 import { Location, CostTrackingData } from '@/app/types';

--- a/src/app/admin/components/__tests__/CostTrackingLinksManager.test.tsx
+++ b/src/app/admin/components/__tests__/CostTrackingLinksManager.test.tsx
@@ -9,8 +9,8 @@ import {
   useUnlinkExpense
 } from '@/app/hooks/useExpenseLinks';
 
-jest.mock('../../../hooks/useExpenses');
-jest.mock('../../../hooks/useExpenseLinks');
+jest.mock('@/app/hooks/useExpenses');
+jest.mock('@/app/hooks/useExpenseLinks');
 
 const mockUseExpenses = useExpenses as jest.MockedFunction<typeof useExpenses>;
 const mockUseExpenseLinks = useExpenseLinks as jest.MockedFunction<typeof useExpenseLinks>;

--- a/src/app/admin/components/__tests__/LinkedExpensesDisplay.real-data.test.tsx
+++ b/src/app/admin/components/__tests__/LinkedExpensesDisplay.real-data.test.tsx
@@ -11,7 +11,7 @@ import { useExpenses } from '@/app/hooks/useExpenses';
 import { Accommodation, Expense, Location, Transportation } from '@/app/types';
 
 // Mock the cost utils
-jest.mock('../../../lib/costUtils', () => ({
+jest.mock('@/app/lib/costUtils', () => ({
   formatCurrency: (amount: number, currency: string) => `${currency} ${amount.toFixed(2)}`,
   formatDate: (date: Date | string) => {
     const d = date instanceof Date ? date : new Date(date);
@@ -19,8 +19,8 @@ jest.mock('../../../lib/costUtils', () => ({
   }
 }));
 
-jest.mock('../../../hooks/useExpenseLinks');
-jest.mock('../../../hooks/useExpenses');
+jest.mock('@/app/hooks/useExpenseLinks');
+jest.mock('@/app/hooks/useExpenses');
 
 const mockUseExpenseLinks = useExpenseLinks as jest.MockedFunction<typeof useExpenseLinks>;
 const mockUseExpenses = useExpenses as jest.MockedFunction<typeof useExpenses>;

--- a/src/app/admin/components/__tests__/LinkedExpensesDisplay.test.tsx
+++ b/src/app/admin/components/__tests__/LinkedExpensesDisplay.test.tsx
@@ -5,7 +5,7 @@ import * as useExpenseLinksModule from '@/app/hooks/useExpenseLinks';
 import * as useExpensesModule from '@/app/hooks/useExpenses';
 
 // Mock the cost utils
-jest.mock('../../../lib/costUtils', () => ({
+jest.mock('@/app/lib/costUtils', () => ({
   formatCurrency: (amount: number, currency: string) => `${currency} ${amount.toFixed(2)}`,
   formatDate: (date: Date | string) => {
     const d = date instanceof Date ? date : new Date(date);
@@ -13,8 +13,8 @@ jest.mock('../../../lib/costUtils', () => ({
   }
 }));
 
-jest.mock('../../../hooks/useExpenseLinks');
-jest.mock('../../../hooks/useExpenses');
+jest.mock('@/app/hooks/useExpenseLinks');
+jest.mock('@/app/hooks/useExpenses');
 
 const mockUseExpenseLinks = jest.mocked(useExpenseLinksModule.useExpenseLinks);
 const mockUseExpenses = jest.mocked(useExpensesModule.useExpenses);

--- a/src/app/components/Timeline.tsx
+++ b/src/app/components/Timeline.tsx
@@ -2,12 +2,11 @@
 
 import { useState, useEffect } from 'react';
 import { format } from 'date-fns';
-import { Journey, JourneyDay, Transportation } from '@/app/types';
+import { CostTrackingData, Journey, JourneyDay, Transportation } from '@/app/types';
 import { transportationColors } from '@/app/lib/routeUtils';
 import { ExpenseTravelLookup } from '@/app/lib/expenseTravelLookup';
 import AccommodationDisplay from '@/app/components/AccommodationDisplay';
 import TikTokIcon from '@/app/components/icons/TikTokIcon';
-import { CostTrackingData } from '@/app/types';
 import { formatCurrency } from '@/app/lib/costUtils';
 
 interface TimelineProps {


### PR DESCRIPTION
## Summary
- normalize component imports to use `@/app/...` aliases
- consolidate `@/app/types` usage in Timeline
- update test mocks and route utils to alias imports

## Tests
- bun run test:unit -- LinkedExpensesDisplay