### PR TITLE
Use server domain config for embed fetch

### DIFF
--- a/src/app/embed/[id]/page.tsx
+++ b/src/app/embed/[id]/page.tsx
@@ -1,6 +1,8 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { NextRequest } from 'next/server';
 import { getDomainConfig, getMapUrl } from '@/app/lib/domains';
+import { GET as getTravelDataApi } from '@/app/api/travel-data/route';
 import EmbeddableMap from '@/app/map/[id]/components/EmbeddableMap';
 import { formatUtcDate } from '@/app/lib/dateUtils';
 import InstagramIcon from '@/app/components/icons/InstagramIcon';
@@ -43,10 +45,12 @@ interface TravelData {
 
 async function getTravelData(id: string): Promise<TravelData | null> {
   try {
+    // Call API route handler directly to avoid network round trip
     const { embedDomain } = getDomainConfig();
-    const response = await fetch(`${embedDomain}/api/travel-data?id=${id}`, {
-      cache: 'no-store' // Always fetch fresh data
-    });
+    const baseUrl = embedDomain || 'http://localhost:3000';
+    const url = new URL(`${baseUrl}/api/travel-data?id=${id}`);
+    const request = new NextRequest(url);
+    const response = await getTravelDataApi(request);
 
     if (!response.ok) {
       return null;

--- a/src/app/map/[id]/page.tsx
+++ b/src/app/map/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { headers } from 'next/headers';
-// import { getEmbedUrl } from '@/app/lib/domains';
+import { getDomainConfig } from '@/app/lib/domains';
 import EmbeddableMap from './components/EmbeddableMap';
 import { formatDateRange, formatUtcDate, normalizeUtcDateToLocalDay } from '@/app/lib/dateUtils';
 import { Location, Transportation, TripUpdate, MapRouteSegment } from '@/app/types';
@@ -82,8 +82,8 @@ const toRouteSegment = (route: Transportation): MapRouteSegment => {
 };
 async function getTravelData(id: string, isAdmin: boolean = false): Promise<TravelData | null> {
   try {
-    // Use unified API for both server and client side
-    const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000';
+    const { embedDomain } = getDomainConfig();
+    const baseUrl = embedDomain || 'http://localhost:3000';
     
     // In admin mode, try to load shadow data first, fallback to regular data
     if (isAdmin) {


### PR DESCRIPTION
## Summary
- remove unreachable window-based branch when loading embed travel data
- rely on server domain config to build the API request URL

## Testing
- bun run test:unit