### PR TITLE
Refactor useTripEditor to use centralized geocoding service

### DIFF
--- a/src/app/admin/edit/[tripId]/hooks/useTripEditor.ts
+++ b/src/app/admin/edit/[tripId]/hooks/useTripEditor.ts
@@ -747,8 +747,12 @@ export function useTripEditor(tripId: string | null) {
 
   const geocodeLocation = useCallback(async (locationName: string): Promise<[number, number]> => {
     const result = await geocodeLocationService(locationName);
-    return result ?? [0, 0];
-  }, []);
+    if (!result) {
+      showNotification(`Could not find coordinates for "${locationName}". Please enter them manually.`, 'error');
+      return [0, 0];
+    }
+    return result;
+  }, [showNotification]);
 
   // Wrapper functions for imported utilities
   const getMapUrlWrapper = (tripId: string) => getMapUrl(tripId);


### PR DESCRIPTION
## Summary
- Replace direct `fetch` call to Nominatim API in `useTripEditor.ts` with the centralized `geocodeLocation` service from `@/app/services/geocoding`
- Ensures consistent behavior with `useShadowTripEditor` which already uses this service
- Provides proper rate limiting (1100ms delay) and User-Agent headers required by Nominatim usage policy

## Test plan
- [ ] Verify geocoding still works when adding/editing locations in the trip editor
- [ ] Confirm no TypeScript or linting errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization to improve maintainability. No changes to user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->