### PR TITLE
Use most common category as default for YNAB import payees

### DIFF
--- a/src/app/admin/components/YnabImportForm.tsx
+++ b/src/app/admin/components/YnabImportForm.tsx
@@ -88,25 +88,33 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
 
   // Calculate the most common category from historical expenses to use as default
   const mostCommonCategory = useMemo(() => {
-    // Count category frequencies from all expenses
-    const categoryCounts = new Map<string, number>();
+    const DEFAULT_FALLBACK = 'Miscellaneous';
 
-    (costData.expenses || []).forEach(expense => {
+    // If no categories available, return hardcoded fallback
+    if (!availableCategories || availableCategories.length === 0) {
+      return DEFAULT_FALLBACK;
+    }
+
+    // Use reduce to find the most common category in a single pass
+    const categoryFrequency = (costData.expenses || []).reduce((acc, expense) => {
       if (expense.category && availableCategories.includes(expense.category)) {
-        categoryCounts.set(expense.category, (categoryCounts.get(expense.category) || 0) + 1);
+        acc[expense.category] = (acc[expense.category] || 0) + 1;
       }
-    });
+      return acc;
+    }, {} as Record<string, number>);
 
-    // Find the category with the highest count
+    // Find the category with the highest frequency
+    let mostCommon = availableCategories.includes(DEFAULT_FALLBACK)
+      ? DEFAULT_FALLBACK
+      : availableCategories[0];
     let maxCount = 0;
-    let mostCommon = availableCategories[0]; // fallback to first alphabetically if no expenses
 
-    categoryCounts.forEach((count, category) => {
+    for (const [category, count] of Object.entries(categoryFrequency)) {
       if (count > maxCount) {
         maxCount = count;
         mostCommon = category;
       }
-    });
+    }
 
     return mostCommon;
   }, [costData.expenses, availableCategories]);


### PR DESCRIPTION
Previously, new payees during YNAB import were assigned the first category alphabetically (availableCategories[0]). This change implements intelligent defaulting that analyzes historical expense data to determine the most frequently used category and uses that as the default for new payees.

Changes:
- Added mostCommonCategory useMemo hook to calculate the most common category from all historical expenses
- Updated getDefaultCategoryForTransaction to use mostCommonCategory as the fallback instead of availableCategories[0]
- Falls back to alphabetically first category only when no expense history exists

This provides a smarter default that reduces manual intervention required after importing new payees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default category selection in the YNAB import form. The system now analyzes your expense data to suggest the most frequently used category as the default, and falls back to "Miscellaneous" when no match is found—providing more relevant, personalized defaults during import.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->