### PR TITLE
Implement keyboard navigation for interactive map

### DIFF
--- a/src/app/lib/mapIconUtils.ts
+++ b/src/app/lib/mapIconUtils.ts
@@ -82,13 +82,17 @@ export const createMarkerKeyHandlers = (onActivate: () => void): MarkerKeyHandle
       activationRef.current = next;
     },
     add: (event: LeafletEvent) => {
-      const element = (event.target as Marker).getElement?.();
-      if (!element) return;
+      const wrapper = (event.target as Marker).getElement?.();
+      if (!wrapper) return;
+      // Find the inner focusable element (.travel-marker-interactive has tabindex)
+      const element = wrapper.querySelector<HTMLElement>('.travel-marker-interactive') ?? wrapper;
       element.addEventListener('keydown', keydownHandler);
     },
     remove: (event: LeafletEvent) => {
-      const element = (event.target as Marker).getElement?.();
-      if (!element) return;
+      const wrapper = (event.target as Marker).getElement?.();
+      if (!wrapper) return;
+      // Find the inner focusable element (.travel-marker-interactive has tabindex)
+      const element = wrapper.querySelector<HTMLElement>('.travel-marker-interactive') ?? wrapper;
       element.removeEventListener('keydown', keydownHandler);
     },
   };
@@ -98,14 +102,18 @@ export const attachMarkerKeyHandlers = (marker: Marker, onActivate: () => void) 
   const keydownHandler = createKeyboardActivationHandler(onActivate);
 
   const addHandler = () => {
-    const element = marker.getElement();
-    if (!element) return;
+    const wrapper = marker.getElement();
+    if (!wrapper) return;
+    // Find the inner focusable element (.travel-marker-interactive has tabindex)
+    const element = wrapper.querySelector<HTMLElement>('.travel-marker-interactive') ?? wrapper;
     element.addEventListener('keydown', keydownHandler);
   };
 
   const removeHandler = () => {
-    const element = marker.getElement();
-    if (!element) return;
+    const wrapper = marker.getElement();
+    if (!wrapper) return;
+    // Find the inner focusable element (.travel-marker-interactive has tabindex)
+    const element = wrapper.querySelector<HTMLElement>('.travel-marker-interactive') ?? wrapper;
     element.removeEventListener('keydown', keydownHandler);
   };
 


### PR DESCRIPTION
## Summary
- Add Tab/Shift+Tab roving focus between markers and groups
- Add Home/End to jump to first/last marker
- Add arrow keys for map panning in each direction
- Add +/- for zoom in/out
- Add Escape to close popups
- Add screen reader announcements via aria-live region
- Track marker elements and focus handlers for proper cleanup
- Focus order: single markers → group badges → collapse markers

## Changes
- : Admin map with full keyboard navigation
- : Public embeddable map with same accessibility patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full keyboard navigation for maps (Tab/Shift‑Tab, Home/End, arrows to pan, +/- to zoom, Escape to close).
  * Improved screen‑reader/live‑region announcements and refined focus order for markers and groups.
  * Map popups now include enriched dynamic content (Wikipedia and weather).

* **Bug Fixes**
  * More robust marker focus registration and cleanup; keyboard activation targets and listener handling made more reliable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->