### PR TITLE
Embeddable map: default Start/End markers off (Vibe Kanban)

### DIFF
--- a/src/app/map/[id]/components/EmbeddableMap.tsx
+++ b/src/app/map/[id]/components/EmbeddableMap.tsx
@@ -527,7 +527,8 @@ const EmbeddableMap: React.FC<EmbeddableMapProps> = ({ travelData }) => {
 
     // Create layer groups for different map elements
     const locationMarkersLayer = L.layerGroup().addTo(map);
-    const startEndLayer = L.layerGroup().addTo(map);
+    // Start/end markers are available via the layer control, but off by default.
+    const startEndLayer = L.layerGroup();
     const routeLayersByType = new globalThis.Map<string, L.LayerGroup>();
     const spiderfyLegsLayer = L.layerGroup().addTo(map);
 


### PR DESCRIPTION
## What
- The “Start / End” marker overlay is now disabled by default on the embeddable map (`/map/[id]`), while remaining available in the layer control.

## Why
The start/end markers are useful context, but having them enabled by default adds visual noise (especially on trips with many location markers). The task request was to make this layer turned off by default, letting users opt in when needed.

## Implementation details
- `startEndLayer` is no longer added to the map at creation time; it becomes visible only when the user enables the “Start / End” overlay from the Leaflet layer control.
- Start/end markers are still created and added to `startEndLayer`, so toggling the overlay immediately shows/hides them without recomputing.

## Verification
- `bun run lint`
- `bun run test:unit`
- `bun run test:integration`
- `bun run build`

This PR was written using [Vibe Kanban](https://vibekanban.com)
