### PR TITLE
Fix calendar tab order to follow trip chronology (Vibe Kanban)

### DIFF
--- a/src/app/__tests__/unit/calendar-accessibility.test.tsx
+++ b/src/app/__tests__/unit/calendar-accessibility.test.tsx
@@ -56,7 +56,7 @@ describe('Trip calendar accessibility', () => {
     const cells = screen.getAllByRole('gridcell');
     expect(cells.length).toBeGreaterThan(0);
     const focusableCells = cells.filter(cell => cell.getAttribute('tabindex') === '0');
-    expect(focusableCells).toHaveLength(1);
+    expect(focusableCells).toHaveLength(cells.length);
     const selectedCell = screen.getByRole('gridcell', { name: /january 3, 2024/i });
     expect(selectedCell).toHaveAttribute('tabindex', '0');
     expect(selectedCell).toHaveAttribute('aria-label');
@@ -83,8 +83,7 @@ describe('Trip calendar accessibility', () => {
     );
 
     const cells = screen.getAllByRole('gridcell');
-    expect(cells[0]).toHaveAttribute('tabindex', '0');
-    expect(cells.slice(1).every(cell => cell.getAttribute('tabindex') === '-1')).toBe(true);
+    expect(cells.every(cell => cell.getAttribute('tabindex') === '0')).toBe(true);
     act(() => {
       cells[0].focus();
     });

--- a/src/app/components/TripCalendar/CalendarDayCell.tsx
+++ b/src/app/components/TripCalendar/CalendarDayCell.tsx
@@ -10,7 +10,6 @@ interface CalendarDayCellProps {
   cell: CalendarCell;
   isSelected: boolean;
   isToday: boolean;
-  isFocusable: boolean;
   onSelectLocation: (
     day: CalendarDay,
     location: Location,
@@ -21,7 +20,6 @@ interface CalendarDayCellProps {
   registerCell: (row: number, col: number, element: HTMLElement | null) => void;
   onNavigate: (row: number, col: number, key: string) => void;
   onAnnounce: (message: string) => void;
-  onFocusCell: (row: number, col: number) => void;
 }
 
 const isShadowLocationName = (location?: Location | null) =>
@@ -63,14 +61,12 @@ export default function CalendarDayCell({
   cell,
   isSelected,
   isToday,
-  isFocusable,
   onSelectLocation,
   locationColors,
   gridPosition,
   registerCell,
   onNavigate,
   onAnnounce,
-  onFocusCell,
 }: CalendarDayCellProps) {
   const { day, backgroundColor, textColor, diagonalSplit, mergeInfo } = cell;
   const hasSideTrips = !!day.sideTrips && day.sideTrips.length > 0;
@@ -104,6 +100,10 @@ export default function CalendarDayCell({
 
   // Check if this is a shadow location
   const isShadowLocation = isShadowLocationName(day.primaryLocation) || isShadowLocationName(day.secondaryLocation);
+
+  const isLocationDay = !day.isOutsideTrip && !day.isOutsideMonth && (
+    Boolean(day.primaryLocation) || Boolean(day.secondaryLocation) || Boolean(day.sideTrips && day.sideTrips.length > 0)
+  );
 
   const baseClasses = `
     h-20 min-h-20 border border-gray-200 cursor-pointer relative overflow-hidden
@@ -162,14 +162,11 @@ export default function CalendarDayCell({
       style={cellStyle}
       onClick={handlePrimaryClick}
       role="gridcell"
-      tabIndex={isFocusable ? 0 : -1}
+      tabIndex={isLocationDay ? 0 : -1}
       aria-label={ariaLabel}
       aria-selected={ariaSelected}
       aria-disabled={ariaDisabled}
       aria-colspan={mergeInfo?.colspan && mergeInfo.colspan > 1 ? mergeInfo.colspan : undefined}
-      onFocus={() => {
-        onFocusCell(gridPosition.row, gridPosition.col);
-      }}
       onKeyDown={event => {
         if (event.key === 'Enter' || event.key === ' ') {
           event.preventDefault();

--- a/src/app/components/TripCalendar/CalendarGrid.tsx
+++ b/src/app/components/TripCalendar/CalendarGrid.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { MonthCalendar, CalendarDay } from '@/app/lib/calendarUtils';
 import { Location } from '@/app/types';
 import CalendarDayCell from './CalendarDayCell';
@@ -21,8 +21,6 @@ interface CalendarGridProps {
 
 const DAYS_OF_WEEK = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
 
-type GridPosition = { row: number; col: number };
-
 export default function CalendarGrid({
   monthCalendar,
   selectedDate,
@@ -41,44 +39,6 @@ export default function CalendarGrid({
     [monthCalendar.weeks]
   );
 
-  const initialActiveCell = useMemo<GridPosition>(() => {
-    const isRenderableCell = (row: number, col: number) => {
-      const cell = weeks[row]?.[col];
-      if (!cell) return false;
-      if (cell.day.isOutsideMonth) return false;
-      if (cell.mergeInfo && cell.mergeInfo.colspan === 0) return false;
-      return true;
-    };
-
-    if (selectedDate) {
-      const selectedTime = selectedDate.getTime();
-      for (let row = 0; row < weeks.length; row += 1) {
-        for (let col = 0; col < 7; col += 1) {
-          const cell = weeks[row]?.[col];
-          if (!cell) continue;
-          if (!isRenderableCell(row, col)) continue;
-          if (cell.day.date.getTime() === selectedTime) {
-            return { row, col };
-          }
-        }
-      }
-    }
-
-    for (let row = 0; row < weeks.length; row += 1) {
-      for (let col = 0; col < 7; col += 1) {
-        if (isRenderableCell(row, col)) return { row, col };
-      }
-    }
-
-    return { row: 0, col: 0 };
-  }, [selectedDate, weeks]);
-
-  const [activeCell, setActiveCell] = useState<GridPosition>(initialActiveCell);
-
-  useEffect(() => {
-    setActiveCell(initialActiveCell);
-  }, [initialActiveCell]);
-
   const registerCell = useCallback((row: number, col: number, element: HTMLElement | null) => {
     const key = `${row}:${col}`;
     if (!element) {
@@ -91,7 +51,6 @@ export default function CalendarGrid({
   const focusCell = useCallback((row: number, col: number) => {
     const element = cellRefs.current.get(`${row}:${col}`);
     if (!element) return false;
-    setActiveCell({ row, col });
     element.focus();
     return true;
   }, []);
@@ -167,10 +126,9 @@ export default function CalendarGrid({
               <CalendarDayCell
                 key={`${weekIndex}-${dayIndex}`}
                 cell={cell}
-                isSelected={selectedDate ? 
+                isSelected={selectedDate ?
                   cell.day.date.getTime() === selectedDate.getTime() : false}
                 isToday={false} // Disabled to prevent hydration mismatch
-                isFocusable={activeCell.row === weekIndex && activeCell.col === dayIndex}
                 onSelectLocation={(day, location, options) =>
                   onLocationSelect(day, location, options)
                 }
@@ -179,7 +137,6 @@ export default function CalendarGrid({
                 registerCell={registerCell}
                 onNavigate={handleNavigate}
                 onAnnounce={onAnnounce}
-                onFocusCell={(row, col) => setActiveCell({ row, col })}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- make every calendar day containing a location (including transitions and side trips) individually tabbable so tabbing follows chronological order within a month
- simplify focus management by removing the roving active-cell state while keeping arrow-key navigation intact
- update calendar accessibility test expectations to match the new tabbing behavior

## Motivation
- keyboard users reported the tab order skipping to next month headers while intervening trip days were present; aligning tab order with actual travel dates improves accessibility and map/calendar consistency

## Testing
- bun run test:unit --runTestsByPath src/app/__tests__/unit/calendar-accessibility.test.tsx

This PR was written using [Vibe Kanban](https://vibekanban.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated calendar accessibility tests to validate focus handling across all grid cells.

* **Refactor**
  * Simplified calendar component focus management by removing unnecessary state tracking while maintaining proper focus behavior for location-based calendar days.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->