### PR TITLE
Cost tracker: apply country exclusions to leaderboards (Vibe Kanban)

### DIFF
--- a/src/app/__tests__/lib/countryInclusions.test.ts
+++ b/src/app/__tests__/lib/countryInclusions.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from '@jest/globals';
+import type { Expense } from '@/app/types';
+import {
+  GENERAL_COUNTRY_LABEL,
+  UNASSIGNED_COUNTRY_LABEL,
+  deriveExcludedCountries,
+  filterExpensesByExcludedCountries,
+  getExpenseCountryLabel
+} from '@/app/lib/countryInclusions';
+
+const baseExpense: Expense = {
+  id: 'expense-1',
+  date: new Date('2024-01-01'),
+  amount: 10,
+  currency: 'EUR',
+  category: 'Food',
+  country: 'France',
+  description: 'Lunch',
+  expenseType: 'actual',
+};
+
+describe('countryInclusions', () => {
+  describe('getExpenseCountryLabel', () => {
+    it('returns General for general expenses', () => {
+      const expense: Expense = { ...baseExpense, isGeneralExpense: true, country: 'France' };
+      expect(getExpenseCountryLabel(expense)).toBe(GENERAL_COUNTRY_LABEL);
+    });
+
+    it('returns trimmed country for non-general expenses', () => {
+      const expense: Expense = { ...baseExpense, isGeneralExpense: false, country: '  Japan  ' };
+      expect(getExpenseCountryLabel(expense)).toBe('Japan');
+    });
+
+    it('returns Unassigned when country is blank for non-general expenses', () => {
+      const expense: Expense = { ...baseExpense, isGeneralExpense: false, country: '   ' };
+      expect(getExpenseCountryLabel(expense)).toBe(UNASSIGNED_COUNTRY_LABEL);
+    });
+  });
+
+  describe('deriveExcludedCountries', () => {
+    it('adds Unassigned when General is excluded', () => {
+      const derived = deriveExcludedCountries([GENERAL_COUNTRY_LABEL]);
+      expect(derived.has(GENERAL_COUNTRY_LABEL)).toBe(true);
+      expect(derived.has(UNASSIGNED_COUNTRY_LABEL)).toBe(true);
+    });
+
+    it('does not add Unassigned when General is not excluded', () => {
+      const derived = deriveExcludedCountries(['France']);
+      expect(derived.has(UNASSIGNED_COUNTRY_LABEL)).toBe(false);
+    });
+  });
+
+  describe('filterExpensesByExcludedCountries', () => {
+    it('filters expenses based on derived excluded countries', () => {
+      const expenses: Expense[] = [
+        { ...baseExpense, id: 'fr', country: 'France', isGeneralExpense: false },
+        { ...baseExpense, id: 'jp', country: 'Japan', isGeneralExpense: false },
+        { ...baseExpense, id: 'gen', country: 'General', isGeneralExpense: true },
+        { ...baseExpense, id: 'unas', country: '', isGeneralExpense: false },
+      ];
+
+      const filtered = filterExpensesByExcludedCountries(expenses, [GENERAL_COUNTRY_LABEL, 'Japan']);
+      const filteredIds = new Set(filtered.map(e => e.id));
+
+      expect(filteredIds.has('fr')).toBe(true);
+      expect(filteredIds.has('jp')).toBe(false);
+      expect(filteredIds.has('gen')).toBe(false);
+      // Unassigned is implicitly excluded when General is excluded.
+      expect(filteredIds.has('unas')).toBe(false);
+    });
+  });
+});
+

--- a/src/app/admin/components/CostTracking/ExpenseLeaderboards.tsx
+++ b/src/app/admin/components/CostTracking/ExpenseLeaderboards.tsx
@@ -5,6 +5,7 @@ import { Expense, Location } from '@/app/types';
 import { formatCurrency } from '@/app/lib/costUtils';
 import { calculateDurationInDays } from '@/app/lib/durationUtils';
 import { LocationExpenseTotal } from '@/app/lib/expenseTravelLookup';
+import { getExpenseCountryLabel } from '@/app/lib/countryInclusions';
 
 type LeaderboardBreakdownItem = {
   label: string;
@@ -138,7 +139,7 @@ const buildLeaderboardEntries = (
   buildGenericLeaderboardEntries(
     expenses,
     getLabel,
-    expense => expense.country?.trim() || 'General'
+    expense => getExpenseCountryLabel(expense)
   );
 
 /**
@@ -156,7 +157,7 @@ const buildCategoryLeaderboardEntries = (
     expense => expense.category,
     expense =>
       breakdownType === 'country'
-        ? expense.country?.trim() || 'General'
+        ? getExpenseCountryLabel(expense)
         : expense.notes?.trim() || expense.source?.trim() || 'Unknown'
   );
 

--- a/src/app/lib/countryInclusions.ts
+++ b/src/app/lib/countryInclusions.ts
@@ -1,0 +1,34 @@
+import type { Expense } from '@/app/types';
+
+export const GENERAL_COUNTRY_LABEL = 'General';
+export const UNASSIGNED_COUNTRY_LABEL = 'Unassigned';
+
+export function getExpenseCountryLabel(expense: Expense): string {
+  if (expense.isGeneralExpense) {
+    return GENERAL_COUNTRY_LABEL;
+  }
+
+  const country = expense.country?.trim();
+  return country ? country : UNASSIGNED_COUNTRY_LABEL;
+}
+
+export function deriveExcludedCountries(excludedCountries: string[]): Set<string> {
+  const derived = new Set(excludedCountries);
+
+  // Align with charts: excluding "General" also removes unassigned/no-country expenses.
+  if (derived.has(GENERAL_COUNTRY_LABEL)) {
+    derived.add(UNASSIGNED_COUNTRY_LABEL);
+  }
+
+  return derived;
+}
+
+export function filterExpensesByExcludedCountries(expenses: Expense[], excludedCountries: string[]): Expense[] {
+  if (excludedCountries.length === 0) {
+    return expenses;
+  }
+
+  const excluded = deriveExcludedCountries(excludedCountries);
+  return expenses.filter(expense => !excluded.has(getExpenseCountryLabel(expense)));
+}
+


### PR DESCRIPTION
This PR makes the cost-tracking leaderboards follow the same country include/exclude selection used by the cost totals (charts/summary), so the UI stays consistent when you toggle countries.

## What changed
- Lifted the `excludedCountries` state to the cost tracker editor and passed it down as a controlled prop to the spending analysis UI.
- Filtered the expenses used for leaderboard calculations based on the current exclusions, and used the filtered set for:
  - Expense leaderboards (repeated descriptions, payees, categories)
  - Location-based leaderboards (via `locationTotals`)
- Centralized country label logic so leaderboards match the rest of the app:
  - General expenses group as `General`
  - Blank/no-country non-general expenses group as `Unassigned`
  - Excluding `General` also excludes `Unassigned` (same behaviour as the charts)
- Added unit coverage for the derived exclusion logic and expense filtering.

## Why
Previously, excluding a country from the cost totals affected the charts/summary, but the cost-related leaderboards still used the full expense set. This caused confusing mismatches (e.g., totals saying one thing while leaderboards ranked spending from excluded countries). This change ensures the leaderboards reflect the same “included” scope the user is viewing.

## Implementation notes
- The exclusion logic lives in a small shared helper (`src/app/lib/countryInclusions.ts`) to avoid duplicating the “General implies Unassigned” rule in multiple UI components.
- Leaderboards remain display-only: exclusions do not modify saved cost data; they only change what inputs the leaderboard aggregations operate on.

This PR was written using [Vibe Kanban](https://vibekanban.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to exclude countries from cost tracking and analysis views
  * Unassigned expenses automatically filter when excluding the general category
  * Expense data and cost charts dynamically update based on country selections

* **Improvements**
  * Enhanced consistency in country label display across reporting views

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->