### PR TITLE
Fix cost tracker trip average

### DIFF
--- a/src/app/admin/components/CostTracking/CostSummaryDashboard.tsx
+++ b/src/app/admin/components/CostTracking/CostSummaryDashboard.tsx
@@ -459,13 +459,28 @@ export default function CostSummaryDashboard({
             tone={budgetBalanceTone}
           />
           {isCompletedTrip ? (
-            <MetricCard
-              label="During trip"
-              value={formatCurrency(costSummary.tripSpent, costData.currency)}
-              supporting="Expenses dated inside the trip."
-              detail={costSummary.tripRefunds > 0 ? `${formatCurrency(costSummary.tripRefunds, costData.currency)} refunded.` : undefined}
-              tone="cobalt"
-            />
+            <>
+              <MetricCard
+                label="Actual spend"
+                value={includedSpendingDisplay.displayText}
+                supporting="Pre-trip and trip-date actuals."
+                detail={analytics.includedRefunds > 0
+                  ? `${formatCurrency(analytics.includedRefunds, costData.currency)} refunded.`
+                  : undefined}
+                tone="slate"
+              />
+              <MetricCard
+                label="Trip average"
+                value={analytics.includedAveragePerDay === null ? 'N/A' : formatCurrency(analytics.includedAveragePerDay, costData.currency)}
+                supporting={analytics.includedDays > 0
+                  ? `${analytics.includedDays} day${analytics.includedDays === 1 ? '' : 's'} counted.`
+                  : 'No days in view.'}
+                detail={excludedCountries.length > 0
+                  ? 'Actual spend, exclusions applied.'
+                  : 'Actual spend over trip days.'}
+                tone="sky"
+              />
+            </>
           ) : (
             <MetricCard
               label="Daily budget"
@@ -475,26 +490,30 @@ export default function CostSummaryDashboard({
               tone="cobalt"
             />
           )}
-          <MetricCard
-            label="Actual spend"
-            value={includedSpendingDisplay.displayText}
-            supporting="Pre-trip and trip-date actuals."
-            detail={analytics.includedRefunds > 0
-              ? `${formatCurrency(analytics.includedRefunds, costData.currency)} refunded.`
-              : undefined}
-            tone="slate"
-          />
-          <MetricCard
-            label={isCompletedTrip ? 'Trip average' : 'Included daily average'}
-            value={analytics.includedAveragePerDay === null ? 'N/A' : formatCurrency(analytics.includedAveragePerDay, costData.currency)}
-            supporting={analytics.includedDays > 0
-              ? `${analytics.includedDays} day${analytics.includedDays === 1 ? '' : 's'} counted.`
-              : 'No days in view.'}
-            detail={excludedCountries.length > 0
-              ? 'Exclusions applied.'
-              : undefined}
-            tone="sky"
-          />
+          {!isCompletedTrip ? (
+            <>
+              <MetricCard
+                label="Actual spend"
+                value={includedSpendingDisplay.displayText}
+                supporting="Pre-trip and trip-date actuals."
+                detail={analytics.includedRefunds > 0
+                  ? `${formatCurrency(analytics.includedRefunds, costData.currency)} refunded.`
+                  : undefined}
+                tone="slate"
+              />
+              <MetricCard
+                label="Included daily average"
+                value={analytics.includedAveragePerDay === null ? 'N/A' : formatCurrency(analytics.includedAveragePerDay, costData.currency)}
+                supporting={analytics.includedDays > 0
+                  ? `${analytics.includedDays} day${analytics.includedDays === 1 ? '' : 's'} counted.`
+                  : 'No days in view.'}
+                detail={excludedCountries.length > 0
+                  ? 'Actual spend, exclusions applied.'
+                  : 'Actual spend over trip days.'}
+                tone="sky"
+              />
+            </>
+          ) : null}
           <MetricCard
             label="Days"
             value={`${analytics.includedDays}`}
@@ -512,6 +531,15 @@ export default function CostSummaryDashboard({
             supporting={analytics.categoryCount > 0 ? `${analytics.categoryCount} categor${analytics.categoryCount === 1 ? 'y' : 'ies'}.` : 'No categories yet.'}
             tone="slate"
           />
+          {isCompletedTrip ? (
+            <MetricCard
+              label="Dated during trip"
+              value={formatCurrency(costSummary.tripSpent, costData.currency)}
+              supporting="Transaction dates inside the trip."
+              detail={costSummary.tripRefunds > 0 ? `${formatCurrency(costSummary.tripRefunds, costData.currency)} refunded.` : undefined}
+              tone="cobalt"
+            />
+          ) : null}
         </div>
       </section>
 

--- a/src/app/admin/components/__tests__/CostSummaryDashboard.test.tsx
+++ b/src/app/admin/components/__tests__/CostSummaryDashboard.test.tsx
@@ -207,6 +207,24 @@ describe('CostSummaryDashboard', () => {
     expect(screen.getByText('8 days counted.')).toBeInTheDocument();
   });
 
+  it('spreads pre-trip actual spend across trip days in the headline average', () => {
+    const costData = buildCostData();
+    costData.expenses.push(buildExpense({
+      id: 'expense-pre-trip-flight',
+      description: 'Pre-trip flight',
+      amount: 2000,
+      category: 'Transportation',
+      country: 'General',
+      isGeneralExpense: true,
+      date: localDay('2026-01-15'),
+    }));
+
+    render(<DashboardHarness costData={costData} />);
+
+    expect(screen.getByText('$167.5')).toBeInTheDocument();
+    expect(screen.getByText('Actual spend over trip days.')).toBeInTheDocument();
+  });
+
   it('drives category context from the selected country analysis row', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     render(<DashboardHarness costData={buildCostData()} />);

--- a/src/app/lib/costDashboardAnalytics.ts
+++ b/src/app/lib/costDashboardAnalytics.ts
@@ -319,8 +319,7 @@ export function buildCostDashboardAnalytics(
   const includedDays = Math.max(0, tripWindow.dayCount - excludedDayKeys.size);
   const includedSpending = countryRows.reduce((sum, country) => sum + country.netSpent, 0);
   const includedRefunds = countryRows.reduce((sum, country) => sum + country.refunds, 0);
-  const includedTripNetSpending = countryRows.reduce((sum, country) => sum + country.tripNetSpent, 0);
-  const includedAveragePerDay = includedDays > 0 ? includedTripNetSpending / includedDays : null;
+  const includedAveragePerDay = includedDays > 0 ? includedSpending / includedDays : null;
   const availableCountryOptions = costSummary.countryBreakdown
     .filter(country => hasCountryDashboardPresence(country, costData))
     .map(country => country.country)


### PR DESCRIPTION
## Summary
- calculate the headline trip average from included actual spend over included trip days
- clarify the card copy so it matches the numerator
- add a regression test for pre-trip actual spend included in the trip average

## Verification
- bun run test:unit -- src/app/admin/components/__tests__/CostSummaryDashboard.test.tsx --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bun run lint
- bun run build