### PR TITLE
Harden OSRM proxy validation

### DIFF
--- a/src/app/__tests__/api/osrm-routing-validation.test.ts
+++ b/src/app/__tests__/api/osrm-routing-validation.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+
+import { GET } from '@/app/api/routing/osrm/route';
+
+const buildRequest = (query: string): NextRequest =>
+  new NextRequest(`http://localhost/api/routing/osrm?${query}`);
+
+describe('OSRM routing proxy validation', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('rejects profiles outside the server allowlist', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    const response = await GET(buildRequest(
+      'profile=http://127.0.0.1&fromLat=51.5&fromLng=-0.1&toLat=48.8&toLng=2.3'
+    ));
+
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid profile' });
+    expect(response.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects partially numeric coordinate values', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    const response = await GET(buildRequest(
+      'profile=car&fromLat=51.5abc&fromLng=-0.1&toLat=48.8&toLng=2.3'
+    ));
+
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid coordinates' });
+    expect(response.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('builds upstream URLs from validated server-owned profile values', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ routes: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const response = await GET(buildRequest(
+      'profile=bike&fromLat=51.5&fromLng=-0.1&toLat=48.8&toLng=2.3'
+    ));
+
+    await expect(response.json()).resolves.toEqual({ routes: [] });
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://router.project-osrm.org/route/v1/bike/-0.1,51.5;2.3,48.8?overview=full&geometries=geojson',
+      expect.objectContaining({
+        cache: 'no-store',
+        headers: { Accept: 'application/json' },
+      })
+    );
+  });
+});

--- a/src/app/api/routing/osrm/route.ts
+++ b/src/app/api/routing/osrm/route.ts
@@ -4,15 +4,27 @@ type OsrmProfile = 'car' | 'bike' | 'foot';
 
 const DEFAULT_OSRM_BASE_URL = 'https://router.project-osrm.org';
 const OSRM_TIMEOUT_MS = 15_000;
-const ALLOWED_PROFILES: Set<OsrmProfile> = new Set<OsrmProfile>(['car', 'bike', 'foot']);
+const OSRM_PROFILE_PATHS = {
+  car: 'car',
+  bike: 'bike',
+  foot: 'foot',
+} as const satisfies Record<OsrmProfile, string>;
 
 const parseFinite = (value: string | null): number | null => {
   if (!value) {
     return null;
   }
 
-  const parsed = Number.parseFloat(value);
+  const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
+};
+
+const getOsrmProfilePath = (value: string | null): string | null => {
+  if (!value || !(value in OSRM_PROFILE_PATHS)) {
+    return null;
+  }
+
+  return OSRM_PROFILE_PATHS[value as OsrmProfile];
 };
 
 const isValidLatitude = (value: number): boolean => value >= -90 && value <= 90;
@@ -34,8 +46,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const fromLng = parseFinite(sp.get('fromLng'));
   const toLat = parseFinite(sp.get('toLat'));
   const toLng = parseFinite(sp.get('toLng'));
+  const profilePath = getOsrmProfilePath(rawProfile);
 
-  if (!rawProfile || !ALLOWED_PROFILES.has(rawProfile as OsrmProfile)) {
+  if (!profilePath) {
     return NextResponse.json({ error: 'Invalid profile' }, { status: 400 });
   }
 
@@ -52,9 +65,8 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid coordinates' }, { status: 400 });
   }
 
-  const profile = rawProfile as OsrmProfile;
   const upstreamUrl = new URL(
-    `/route/v1/${profile}/${fromLng},${fromLat};${toLng},${toLat}`,
+    `/route/v1/${profilePath}/${fromLng},${fromLat};${toLng},${toLat}`,
     getOsrmBaseUrl()
   );
   upstreamUrl.searchParams.set('overview', 'full');


### PR DESCRIPTION
## Summary
- select OSRM profile URL path segments from a server-owned allowlist map
- reject partially numeric coordinate query values before proxying upstream
- add focused API route tests for invalid profile, invalid coordinates, and valid upstream URL construction

## Validation
- bun run test:unit -- src/app/__tests__/api/osrm-routing-validation.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating OSRM routing endpoint behavior, including profile allowlist enforcement, coordinate validation, and upstream request construction.

* **Improvements**
  * Enhanced routing profile validation with stricter checks and improved coordinate parsing logic for more robust request handling and proper error responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->