### PR TITLE
Address OSRM validation review comments

### DIFF
--- a/src/app/__tests__/api/osrm-routing-validation.test.ts
+++ b/src/app/__tests__/api/osrm-routing-validation.test.ts
@@ -26,11 +26,35 @@ describe('OSRM routing proxy validation', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it('rejects inherited object property names as profiles', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    const response = await GET(buildRequest(
+      'profile=toString&fromLat=51.5&fromLng=-0.1&toLat=48.8&toLng=2.3'
+    ));
+
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid profile' });
+    expect(response.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it('rejects partially numeric coordinate values', async () => {
     const fetchSpy = jest.spyOn(global, 'fetch');
 
     const response = await GET(buildRequest(
       'profile=car&fromLat=51.5abc&fromLng=-0.1&toLat=48.8&toLng=2.3'
+    ));
+
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid coordinates' });
+    expect(response.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects whitespace-only coordinate values', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    const response = await GET(buildRequest(
+      'profile=car&fromLat=%20%20%20&fromLng=-0.1&toLat=48.8&toLng=2.3'
     ));
 
     await expect(response.json()).resolves.toEqual({ error: 'Invalid coordinates' });

--- a/src/app/api/routing/osrm/route.ts
+++ b/src/app/api/routing/osrm/route.ts
@@ -11,16 +11,17 @@ const OSRM_PROFILE_PATHS = {
 } as const satisfies Record<OsrmProfile, string>;
 
 const parseFinite = (value: string | null): number | null => {
-  if (!value) {
+  const trimmedValue = value?.trim();
+  if (!trimmedValue) {
     return null;
   }
 
-  const parsed = Number(value);
+  const parsed = Number(trimmedValue);
   return Number.isFinite(parsed) ? parsed : null;
 };
 
 const getOsrmProfilePath = (value: string | null): string | null => {
-  if (!value || !(value in OSRM_PROFILE_PATHS)) {
+  if (!value || !Object.hasOwn(OSRM_PROFILE_PATHS, value)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- reject whitespace-only coordinate query values before numeric parsing
- use an own-property profile lookup so prototype property names cannot pass validation
- add regression tests for inherited profile keys and whitespace-only coordinates

## Follow-up from
- #282 Greptile/Gemini/CodeRabbit review comments

## Validation
- bun run test:unit -- src/app/__tests__/api/osrm-routing-validation.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint
- bun run build