### PR TITLE
Harden Instagram API cookie usage to admin domain

### DIFF
--- a/src/app/api/instagram/route.ts
+++ b/src/app/api/instagram/route.ts
@@ -45,8 +45,9 @@ export async function GET(request: NextRequest) {
   const rawUsername = searchParams.get('username') ?? '';
   const username = normalizeInstagramUsername(rawUsername);
   const instagramAppId = process.env.INSTAGRAM_APP_ID?.trim() || DEFAULT_INSTAGRAM_APP_ID;
-  const isAdmin = await isAdminDomain();
-  const cookieHeader = isAdmin ? buildInstagramCookieHeaderFromEnv() : undefined;
+  const envCookieHeader = buildInstagramCookieHeaderFromEnv();
+  const isAdmin = Boolean(envCookieHeader) && await isAdminDomain();
+  const cookieHeader = isAdmin ? envCookieHeader : undefined;
   const usePrivateCache = Boolean(cookieHeader);
 
   if (!username) {
@@ -158,7 +159,9 @@ export async function GET(request: NextRequest) {
     if (sawLoginRequirement) {
       return NextResponse.json(
         {
-          error: 'Instagram is requiring a logged-in session. Configure INSTAGRAM_SESSIONID (and optionally INSTAGRAM_CSRFTOKEN / INSTAGRAM_DS_USER_ID).'
+          error: isAdmin
+            ? 'Instagram is requiring a logged-in session. Configure INSTAGRAM_SESSIONID (and optionally INSTAGRAM_CSRFTOKEN / INSTAGRAM_DS_USER_ID).'
+            : 'This Instagram profile is not publicly accessible.'
         },
         { status: 403 }
       );

--- a/src/app/api/instagram/route.ts
+++ b/src/app/api/instagram/route.ts
@@ -6,6 +6,7 @@ import {
   normalizeInstagramUsername,
   payloadRequiresInstagramLogin,
 } from '@/app/lib/instagramImportUtils';
+import { isAdminDomain } from '@/app/lib/server-domains';
 
 const DEFAULT_INSTAGRAM_APP_ID = '936619743392459';
 const MAX_IMPORTED_POSTS = 40;
@@ -44,7 +45,8 @@ export async function GET(request: NextRequest) {
   const rawUsername = searchParams.get('username') ?? '';
   const username = normalizeInstagramUsername(rawUsername);
   const instagramAppId = process.env.INSTAGRAM_APP_ID?.trim() || DEFAULT_INSTAGRAM_APP_ID;
-  const cookieHeader = buildInstagramCookieHeaderFromEnv();
+  const isAdmin = await isAdminDomain();
+  const cookieHeader = isAdmin ? buildInstagramCookieHeaderFromEnv() : undefined;
   const usePrivateCache = Boolean(cookieHeader);
 
   if (!username) {


### PR DESCRIPTION
### Motivation
- The public `GET /api/instagram` endpoint was using server-side Instagram session cookies built by `buildInstagramCookieHeaderFromEnv()` for caller-provided usernames, which could let unauthenticated callers use the operator's Instagram session to view follower-only content; the change restricts session-cookie usage to admin-domain requests only.

### Description
- Import `isAdminDomain` and call `await isAdminDomain()` in `src/app/api/instagram/route.ts`, and only call `buildInstagramCookieHeaderFromEnv()` when the request is from the admin domain so non-admin/public requests do not send server Instagram cookies while preserving unauthenticated public-profile fetch behavior.

### Testing
- Ran `bun run test:unit -- src/app/__tests__/lib/instagramImportUtils.test.ts`, which passed (1 suite, 7 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b27581a148333b2a8145970f0e3d0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Instagram integration caching behavior to properly differentiate between admin and standard environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->