### PR TITLE
Protect travel-data PATCH with admin-domain authorization

### DIFF
--- a/src/app/api/travel-data/route.ts
+++ b/src/app/api/travel-data/route.ts
@@ -232,6 +232,11 @@ export async function PUT(request: NextRequest) {
 
 export async function PATCH(request: NextRequest) {
   try {
+    const isAdmin = await isAdminDomain();
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+
     const { searchParams } = new URL(request.url);
     const id = searchParams.get('id');
     

--- a/src/app/api/travel-data/route.ts
+++ b/src/app/api/travel-data/route.ts
@@ -58,8 +58,25 @@ const normalizeCompositeRoutes = (routes?: RoutePayload[]) => {
   return { routes: normalized as RoutePayload[] };
 };
 
+const requireAdminDomain = async (operation: string) => {
+  const isAdmin = await isAdminDomain();
+  if (isAdmin) {
+    return null;
+  }
+
+  return NextResponse.json(
+    { error: `${operation} operation only allowed on admin domain` },
+    { status: 403 }
+  );
+};
+
 export async function POST(request: NextRequest) {
   try {
+    const forbidden = await requireAdminDomain('Create');
+    if (forbidden) {
+      return forbidden;
+    }
+
     const travelData = await request.json();
 
     const { routes, error } = normalizeCompositeRoutes(travelData.routes);
@@ -172,6 +189,11 @@ export async function GET(request: NextRequest) {
 
 export async function PUT(request: NextRequest) {
   try {
+    const forbidden = await requireAdminDomain('Update');
+    if (forbidden) {
+      return forbidden;
+    }
+
     const { searchParams } = new URL(request.url);
     const id = searchParams.get('id');
     
@@ -232,9 +254,9 @@ export async function PUT(request: NextRequest) {
 
 export async function PATCH(request: NextRequest) {
   try {
-    const isAdmin = await isAdminDomain();
-    if (!isAdmin) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    const forbidden = await requireAdminDomain('Patch');
+    if (forbidden) {
+      return forbidden;
     }
 
     const { searchParams } = new URL(request.url);
@@ -439,13 +461,9 @@ export async function PATCH(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
-    // Check if request is from admin domain
-    const isAdmin = await isAdminDomain();
-    if (!isAdmin) {
-      return NextResponse.json(
-        { error: 'Delete operation only allowed on admin domain' },
-        { status: 403 }
-      );
+    const forbidden = await requireAdminDomain('Delete');
+    if (forbidden) {
+      return forbidden;
     }
 
     const { searchParams } = new URL(request.url);


### PR DESCRIPTION
### Motivation
- The `PATCH /api/travel-data` autosave branch accepted attacker-controlled `deltaUpdate` payloads without verifying the request origin, allowing unauthenticated modification of trip metadata, locations, and routes. 
- The change restores parity with the analogous cost-tracking endpoint which already enforces admin-only writes via `isAdminDomain()`.

### Description
- Add an early `isAdminDomain()` check at the start of the `PATCH` handler in `src/app/api/travel-data/route.ts` that returns `403 Unauthorized` for non-admin hosts. 
- This check runs before any request body parsing or delta application, preventing public callers from sending `deltaUpdate` payloads that could modify persisted trip data.

### Testing
- Ran the unit test file `src/app/__tests__/lib/travelDataDelta.test.ts` with `bun run test:unit -- src/app/__tests__/lib/travelDataDelta.test.ts`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b2d03056883338a81a85198243009)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization enforcement across all admin API endpoints. Administrative operations including POST, PUT, PATCH, and DELETE now implement consistent, centralized authorization validation to properly protect sensitive endpoints. Unauthorized requests are correctly rejected with appropriate error responses. This significantly strengthens the overall security posture and access control of the entire API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->