### PR TITLE
Protect expense-links API from public split-data disclosure

### DIFF
--- a/src/app/api/travel-data/[tripId]/expense-links/route.ts
+++ b/src/app/api/travel-data/[tripId]/expense-links/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { loadUnifiedTripData } from '@/app/lib/unifiedDataService';
 import { createExpenseLinkingService } from '@/app/lib/expenseLinkingService';
 import { TravelLinkInfo } from '@/app/lib/expenseTravelLookup';
+import { isAdminDomain } from '@/app/lib/server-domains';
 
 interface ExpenseLink {
   expenseId: string;
@@ -58,6 +59,14 @@ export async function GET(
       return NextResponse.json({ 
         error: 'Trip ID is required' 
       }, { status: 400 });
+    }
+
+    // Restrict expense-link metadata (including split allocation) to admin domain only
+    const isAdmin = await isAdminDomain();
+    if (!isAdmin) {
+      return NextResponse.json({
+        error: 'Unauthorized - admin domain required'
+      }, { status: 403 });
     }
 
     // Load trip data


### PR DESCRIPTION
### Motivation
- The `GET /api/travel-data/[tripId]/expense-links` endpoint exposed private cost allocation fields (`splitMode`/`splitValue`) to unauthenticated callers, so the handler must be restricted to the admin domain to prevent disclosure of exact financial split data.

### Description
- Import `isAdminDomain` and enforce an early admin-domain check in `src/app/api/travel-data/[tripId]/expense-links/route.ts`, returning `403` for non-admin requests while preserving the existing response for authorized admin-domain callers.

### Testing
- Ran the repository lint step with `bun run lint`, which failed in this environment due to an existing `zod` package export mismatch (`./v4/core` not exported) unrelated to this change, so no further automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b355b105083338b19285b64dbb9c8)