### PR TITLE
Protect expense-links API from public split-data disclosure

### DIFF
--- a/src/app/api/travel-data/[tripId]/expense-links/route.ts
+++ b/src/app/api/travel-data/[tripId]/expense-links/route.ts
@@ -65,6 +65,11 @@ export async function GET(
   { params }: { params: Promise<{ tripId: string }> }
 ) {
   try {
+    const forbidden = await requireAdminDomain();
+    if (forbidden) {
+      return forbidden;
+    }
+
     const { tripId } = await params;
 
     if (!tripId) {


### PR DESCRIPTION
Replaces #286 after the original PR could not be reopened once its branch was deleted/recreated. This keeps the remaining read-side guard on top of #287's mutation guard.