### PR TITLE
Harden travel data auth cache boundary

### DIFF
--- a/src/app/__tests__/api/travel-data-auth-cache.test.ts
+++ b/src/app/__tests__/api/travel-data-auth-cache.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+
+import { GET, PATCH } from '@/app/api/travel-data/route';
+import { loadUnifiedTripData, updateTravelData } from '@/app/lib/unifiedDataService';
+
+jest.mock('@/app/lib/server-domains', () => ({
+  __esModule: true,
+  isAdminDomain: jest.fn(),
+  isAdminHost: jest.fn((host: string | null) => host === 'admin.example.test')
+}));
+
+jest.mock('@/app/lib/unifiedDataService', () => ({
+  __esModule: true,
+  deleteTripWithBackup: jest.fn(),
+  loadUnifiedTripData: jest.fn(),
+  updateTravelData: jest.fn()
+}));
+
+const { isAdminDomain: mockIsAdminDomain } = jest.requireMock('@/app/lib/server-domains');
+const mockLoadUnifiedTripData = loadUnifiedTripData as jest.MockedFunction<typeof loadUnifiedTripData>;
+const mockUpdateTravelData = updateTravelData as jest.MockedFunction<typeof updateTravelData>;
+
+const buildTrip = () => ({
+  schemaVersion: 4,
+  id: 'trip-1',
+  title: 'Private Trip',
+  description: 'Trip with admin-only fields',
+  startDate: '2024-01-01',
+  endDate: '2024-01-10',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  travelData: {
+    instagramUsername: 'private-handle',
+    locations: [
+      {
+        id: 'location-1',
+        name: 'Admin Location',
+        coordinates: [52.52, 13.405],
+        costTrackingLinks: [{ expenseId: 'expense-1', linkType: 'manual' }]
+      }
+    ],
+    routes: [
+      {
+        id: 'route-1',
+        from: 'A',
+        to: 'B',
+        privateNotes: 'admin only',
+        costTrackingLinks: [{ expenseId: 'expense-1', linkType: 'manual' }]
+      }
+    ]
+  },
+  accommodations: [],
+  publicUpdates: []
+});
+
+describe('travel-data API auth and cache boundary', () => {
+  const originalAdminDomain = process.env.ADMIN_DOMAIN;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.ADMIN_DOMAIN = 'admin.example.test';
+  });
+
+  afterAll(() => {
+    if (originalAdminDomain === undefined) {
+      delete process.env.ADMIN_DOMAIN;
+    } else {
+      process.env.ADMIN_DOMAIN = originalAdminDomain;
+    }
+  });
+
+  it('rejects unauthenticated delta PATCH before loading or updating trip data', async () => {
+    mockIsAdminDomain.mockResolvedValue(false);
+
+    const request = new NextRequest('https://public.example.test/api/travel-data?id=trip-1', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        deltaUpdate: {
+          locations: {
+            updated: [
+              {
+                id: 'location-1',
+                name: 'Attacker Rewrite'
+              }
+            ]
+          }
+        }
+      })
+    });
+
+    const response = await PATCH(request);
+    const result = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(result).toEqual({ error: 'Patch operation only allowed on admin domain' });
+    expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
+    expect(mockUpdateTravelData).not.toHaveBeenCalled();
+  });
+
+  it('marks admin-domain travel data responses as private and no-store', async () => {
+    mockLoadUnifiedTripData.mockResolvedValue(buildTrip());
+
+    const response = await GET(
+      new NextRequest('https://admin.example.test/api/travel-data?id=trip-1', {
+        headers: { host: 'admin.example.test' }
+      })
+    );
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(result.instagramUsername).toBe('private-handle');
+    expect(result.locations[0].costTrackingLinks).toHaveLength(1);
+    expect(result.routes[0].privateNotes).toBe('admin only');
+  });
+
+  it('keeps public travel data responses cacheable after privacy filtering', async () => {
+    mockLoadUnifiedTripData.mockResolvedValue(buildTrip());
+
+    const response = await GET(
+      new NextRequest('https://public.example.test/api/travel-data?id=trip-1', {
+        headers: { host: 'public.example.test' }
+      })
+    );
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe(
+      'public, max-age=0, s-maxage=86400, stale-while-revalidate=604800'
+    );
+    expect(result.instagramUsername).toBeUndefined();
+    expect(result.locations[0].costTrackingLinks).toBeUndefined();
+    expect(result.routes[0].privateNotes).toBeUndefined();
+  });
+});

--- a/src/app/__tests__/lib/server-domains.test.ts
+++ b/src/app/__tests__/lib/server-domains.test.ts
@@ -1,0 +1,34 @@
+import { isAdminHost } from '@/app/lib/server-domains';
+
+describe('server domain helpers', () => {
+  const originalAdminDomain = process.env.ADMIN_DOMAIN;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    process.env.ADMIN_DOMAIN = 'Admin.Example.Test.';
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value: 'production',
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    if (originalAdminDomain === undefined) {
+      delete process.env.ADMIN_DOMAIN;
+    } else {
+      process.env.ADMIN_DOMAIN = originalAdminDomain;
+    }
+
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value: originalNodeEnv,
+      configurable: true,
+    });
+  });
+
+  it('matches admin hosts case-insensitively and ignores trailing dots', () => {
+    expect(isAdminHost('ADMIN.example.test')).toBe(true);
+    expect(isAdminHost('admin.example.test.')).toBe(true);
+    expect(isAdminHost('admin.example.test:3000')).toBe(true);
+    expect(isAdminHost('public.example.test')).toBe(false);
+  });
+});

--- a/src/app/api/travel-data/route.ts
+++ b/src/app/api/travel-data/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { updateTravelData, loadUnifiedTripData, deleteTripWithBackup } from '@/app/lib/unifiedDataService';
 import { filterTravelDataForServer } from '@/app/lib/serverPrivacyUtils';
-import { isAdminDomain } from '@/app/lib/server-domains';
+import { isAdminDomain, isAdminHost } from '@/app/lib/server-domains';
 import { validateAndNormalizeCompositeRoute } from '@/app/lib/compositeRouteValidation';
 import { applyTravelDataDelta, isTravelDataDelta, isTravelDataDeltaEmpty } from '@/app/lib/travelDataDelta';
 import { dateReviver } from '@/app/lib/jsonDateReviver';
@@ -9,6 +9,8 @@ import type { TravelData } from '@/app/types';
 import { parseDateAsLocalDay } from '@/app/lib/localDateUtils';
 
 const DEBUG_TRAVEL_DATA = process.env.DEBUG_TRAVEL_DATA === 'true';
+const PUBLIC_TRAVEL_DATA_CACHE_CONTROL = 'public, max-age=0, s-maxage=86400, stale-while-revalidate=604800';
+const PRIVATE_TRAVEL_DATA_CACHE_CONTROL = 'no-store';
 
 type RouteSegmentPayload = {
   from: string;
@@ -174,10 +176,13 @@ export async function GET(request: NextRequest) {
       });
     }
     
+    const cacheControl = isAdminHost(host)
+      ? PRIVATE_TRAVEL_DATA_CACHE_CONTROL
+      : PUBLIC_TRAVEL_DATA_CACHE_CONTROL;
+
     return NextResponse.json(filteredData, {
       headers: {
-        // Cache at the CDN for a day; allow serving stale for a week while revalidating
-        'Cache-Control': 'public, max-age=0, s-maxage=86400, stale-while-revalidate=604800'
+        'Cache-Control': cacheControl
       }
     });
   } catch (error) {

--- a/src/app/lib/server-domains.ts
+++ b/src/app/lib/server-domains.ts
@@ -8,15 +8,29 @@ export async function getCurrentDomain(): Promise<string> {
   return `${protocol}://${host}`;
 }
 
+export function isAdminHost(host: string | null): boolean {
+  if (!host) {
+    return false;
+  }
+
+  // Use environment variable for admin domain
+  const adminDomain = process.env.ADMIN_DOMAIN
+    ?.replace(/^https?:\/\//, '')
+    .toLowerCase()
+    .replace(/\.$/, '');
+  const normalizedHost = host.toLowerCase().replace(/\.$/, '');
+
+  return Boolean(
+    (adminDomain && (normalizedHost === adminDomain || normalizedHost.startsWith(`${adminDomain}:`))) ||
+    (process.env.NODE_ENV !== 'production' && (normalizedHost === 'localhost' || normalizedHost.startsWith('localhost:')))
+  );
+}
+
 export async function isAdminDomain(): Promise<boolean> {
   const headersList = await headers();
   const host = headersList.get('host') || '';
-  
-  // Use environment variable for admin domain
-  const adminDomain = process.env.ADMIN_DOMAIN?.replace(/^https?:\/\//, '');
-  
-  return (adminDomain && (host === adminDomain || host.startsWith(adminDomain + ':'))) || 
-         (process.env.NODE_ENV !== 'production' && (host === 'localhost' || host.startsWith('localhost:')));
+
+  return isAdminHost(host);
 }
 
 export async function isEmbedDomain(): Promise<boolean> {


### PR DESCRIPTION
## Summary
- keep admin-domain /api/travel-data responses out of shared/browser caches with Cache-Control: no-store
- preserve public travel-data CDN caching after server-side privacy filtering
- add regression coverage that unauthenticated delta PATCH is rejected before trip data is loaded or updated

## Security findings
- 590374ca55b48191accb3da1d6a94e5e: Unauthenticated delta PATCH can rewrite trip data
- 87de49529c188191a6ecd8b3d941155b: Public caching added to admin-sensitive travel responses

## Validation
- bun run test:unit -- src/app/__tests__/api/travel-data-auth-cache.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bunx eslint src/app/api/travel-data/route.ts src/app/__tests__/api/travel-data-auth-cache.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for API authentication and cache-control boundaries across admin and public request scenarios

* **Improvements**
  * Travel data API now dynamically applies cache-control headers based on request origin
  * Admin-domain requests configured with stricter no-store caching; public-domain requests use standard caching policy
  * Enhanced request origin detection logic for consistent admin domain checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->