### PR TITLE
Protect expense link APIs

### DIFF
--- a/src/app/__tests__/api/expense-links-auth.test.ts
+++ b/src/app/__tests__/api/expense-links-auth.test.ts
@@ -1,0 +1,184 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+import {
+  DELETE as deleteTripExpenseLink,
+  GET as getTripExpenseLinks,
+  POST as postTripExpenseLink,
+} from '@/app/api/travel-data/[tripId]/expense-links/route';
+import {
+  DELETE as deleteLegacyExpenseLink,
+  POST as postLegacyExpenseLink,
+} from '@/app/api/travel-data/expense-links/route';
+import { POST as moveLegacyExpenseLink } from '@/app/api/travel-data/expense-links/move/route';
+
+jest.mock('@/app/lib/server-domains', () => ({
+  __esModule: true,
+  isAdminDomain: jest.fn(),
+}));
+
+jest.mock('@/app/lib/unifiedDataService', () => ({
+  __esModule: true,
+  loadUnifiedTripData: jest.fn(),
+  saveUnifiedTripData: jest.fn(),
+}));
+
+jest.mock('@/app/lib/expenseLinkingService', () => ({
+  __esModule: true,
+  createExpenseLinkingService: jest.fn(() => ({
+    createMultipleLinks: jest.fn(),
+    createOrUpdateLink: jest.fn(),
+    removeLink: jest.fn(),
+  })),
+}));
+
+const { isAdminDomain: mockIsAdminDomain } = jest.requireMock('@/app/lib/server-domains');
+const {
+  loadUnifiedTripData: mockLoadUnifiedTripData,
+  saveUnifiedTripData: mockSaveUnifiedTripData,
+} = jest.requireMock('@/app/lib/unifiedDataService');
+const { createExpenseLinkingService: mockCreateExpenseLinkingService } = jest.requireMock('@/app/lib/expenseLinkingService');
+
+const tripParams = { params: Promise.resolve({ tripId: 'trip-1' }) };
+
+const jsonRequest = (url: string, method: string, body?: unknown): NextRequest =>
+  new NextRequest(url, {
+    method,
+    body: body === undefined ? undefined : JSON.stringify(body),
+    headers: body === undefined ? undefined : { 'Content-Type': 'application/json' },
+  });
+
+const expectForbidden = async (response: Response): Promise<void> => {
+  expect(response.status).toBe(403);
+  await expect(response.json()).resolves.toEqual({
+    error: 'Forbidden - admin domain required',
+  });
+};
+
+describe('expense-link API admin-domain authorization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (mockIsAdminDomain as jest.Mock).mockResolvedValue(false);
+  });
+
+  it('blocks trip-scoped expense-link reads on public domains', async () => {
+    const response = await getTripExpenseLinks(
+      jsonRequest('https://travel.example/api/travel-data/trip-1/expense-links', 'GET'),
+      tripParams
+    );
+
+    await expectForbidden(response);
+    expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
+  });
+
+  it('allows trip-scoped expense-link reads on admin domains', async () => {
+    (mockIsAdminDomain as jest.Mock).mockResolvedValue(true);
+    mockLoadUnifiedTripData.mockResolvedValue({
+      costData: {
+        expenses: [{ id: 'expense-1' }],
+      },
+      travelData: {
+        locations: [
+          {
+            id: 'location-1',
+            name: 'Berlin',
+            costTrackingLinks: [{ expenseId: 'expense-1', splitMode: 'fixed', splitValue: 40 }],
+          },
+        ],
+      },
+    });
+
+    const response = await getTripExpenseLinks(
+      jsonRequest('https://admin.example/api/travel-data/trip-1/expense-links', 'GET'),
+      tripParams
+    );
+
+    await expect(response.json()).resolves.toEqual([
+      {
+        expenseId: 'expense-1',
+        travelItemId: 'location-1',
+        travelItemName: 'Berlin',
+        travelItemType: 'location',
+        description: undefined,
+        splitMode: 'fixed',
+        splitValue: 40,
+      },
+    ]);
+    expect(response.status).toBe(200);
+    expect(mockLoadUnifiedTripData).toHaveBeenCalledWith('trip-1');
+  });
+
+  it('blocks trip-scoped expense-link mutations before parsing private split data', async () => {
+    const response = await postTripExpenseLink(
+      jsonRequest('https://travel.example/api/travel-data/trip-1/expense-links', 'POST', {
+        expenseId: 'expense-1',
+        links: [
+          { type: 'route', id: 'route-1', name: 'Route 1', splitMode: 'fixed', splitValue: 70 },
+          { type: 'route', id: 'route-2', name: 'Route 2', splitMode: 'fixed', splitValue: 20 },
+        ],
+      }),
+      tripParams
+    );
+
+    await expectForbidden(response);
+    expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
+    expect(mockCreateExpenseLinkingService).not.toHaveBeenCalled();
+  });
+
+  it('blocks trip-scoped expense-link deletes on public domains', async () => {
+    const response = await deleteTripExpenseLink(
+      jsonRequest('https://travel.example/api/travel-data/trip-1/expense-links?expenseId=expense-1', 'DELETE'),
+      tripParams
+    );
+
+    await expectForbidden(response);
+    expect(mockCreateExpenseLinkingService).not.toHaveBeenCalled();
+  });
+
+  it('blocks legacy expense-link creation on public domains', async () => {
+    const response = await postLegacyExpenseLink(
+      jsonRequest('https://travel.example/api/travel-data/expense-links', 'POST', {
+        tripId: 'trip-1',
+        expenseId: 'expense-1',
+        travelItemId: 'location-1',
+        travelItemType: 'location',
+      })
+    );
+
+    await expectForbidden(response);
+    expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
+    expect(mockSaveUnifiedTripData).not.toHaveBeenCalled();
+  });
+
+  it('blocks legacy expense-link deletes on public domains', async () => {
+    const response = await deleteLegacyExpenseLink(
+      jsonRequest('https://travel.example/api/travel-data/expense-links', 'DELETE', {
+        tripId: 'trip-1',
+        expenseId: 'expense-1',
+        travelItemId: 'location-1',
+      })
+    );
+
+    await expectForbidden(response);
+    expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
+    expect(mockSaveUnifiedTripData).not.toHaveBeenCalled();
+  });
+
+  it('blocks legacy expense-link moves on public domains', async () => {
+    const response = await moveLegacyExpenseLink(
+      jsonRequest('https://travel.example/api/travel-data/expense-links/move', 'POST', {
+        tripId: 'trip-1',
+        expenseId: 'expense-1',
+        fromTravelItemId: 'location-1',
+        toTravelItemId: 'route-1',
+        toTravelItemType: 'route',
+      })
+    );
+
+    await expectForbidden(response);
+    expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
+    expect(mockSaveUnifiedTripData).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/__tests__/lib/serverPrivacyUtils.test.ts
+++ b/src/app/__tests__/lib/serverPrivacyUtils.test.ts
@@ -1,0 +1,110 @@
+import { filterJourneyForServer, filterTravelDataForServer } from '@/app/lib/serverPrivacyUtils';
+import { Accommodation } from '@/app/types';
+
+describe('server privacy utilities', () => {
+  const originalAdminDomain = process.env.ADMIN_DOMAIN;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  const privateAccommodation: Accommodation = {
+    id: 'acc-1',
+    name: 'Private Hotel',
+    locationId: 'loc-1',
+    accommodationData: 'booking: private',
+    isAccommodationPublic: false,
+    costTrackingLinks: [{ expenseId: 'expense-1', description: 'Hotel cost' }],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  const publicAccommodation: Accommodation = {
+    ...privateAccommodation,
+    id: 'acc-2',
+    name: 'Public Hotel',
+    accommodationData: 'Public stay notes',
+    isAccommodationPublic: true,
+  };
+
+  beforeEach(() => {
+    process.env.ADMIN_DOMAIN = 'admin.example';
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value: 'production',
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    if (originalAdminDomain === undefined) {
+      delete process.env.ADMIN_DOMAIN;
+    } else {
+      process.env.ADMIN_DOMAIN = originalAdminDomain;
+    }
+
+    Object.defineProperty(process.env, 'NODE_ENV', {
+      value: originalNodeEnv,
+      configurable: true,
+    });
+  });
+
+  it('removes private accommodation expense links from public travel data', () => {
+    const result = filterTravelDataForServer(
+      {
+        accommodations: [privateAccommodation, publicAccommodation],
+      },
+      'travel.example'
+    );
+
+    expect(result.accommodations).toEqual([
+      {
+        ...privateAccommodation,
+        accommodationData: undefined,
+        isAccommodationPublic: undefined,
+        costTrackingLinks: undefined,
+      },
+      {
+        ...publicAccommodation,
+        isAccommodationPublic: undefined,
+        costTrackingLinks: undefined,
+      },
+    ]);
+  });
+
+  it('removes top-level accommodation expense links when journey days are present', () => {
+    const result = filterTravelDataForServer(
+      {
+        days: [],
+        accommodations: [privateAccommodation],
+      },
+      'travel.example'
+    );
+
+    expect(result.accommodations?.[0]?.costTrackingLinks).toBeUndefined();
+    expect(result.accommodations?.[0]?.accommodationData).toBeUndefined();
+  });
+
+  it('filters top-level accommodations when filtering journey data directly', () => {
+    const result = filterJourneyForServer(
+      {
+        id: 'trip-1',
+        title: 'Trip',
+        startDate: new Date('2026-01-01T00:00:00.000Z'),
+        days: [],
+        accommodations: [privateAccommodation],
+      } as never,
+      'travel.example'
+    ) as unknown as { accommodations?: Accommodation[] };
+
+    expect(result.accommodations?.[0]?.costTrackingLinks).toBeUndefined();
+    expect(result.accommodations?.[0]?.accommodationData).toBeUndefined();
+  });
+
+  it('preserves accommodation expense links for admin travel data', () => {
+    const result = filterTravelDataForServer(
+      {
+        accommodations: [privateAccommodation],
+      },
+      'admin.example'
+    );
+
+    expect(result.accommodations?.[0]?.costTrackingLinks).toEqual(privateAccommodation.costTrackingLinks);
+  });
+});

--- a/src/app/api/travel-data/expense-links/move/route.ts
+++ b/src/app/api/travel-data/expense-links/move/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { loadUnifiedTripData, saveUnifiedTripData } from '@/app/lib/unifiedDataService';
+import { isAdminDomain } from '@/app/lib/server-domains';
 
 interface MoveExpenseRequest {
   tripId: string;
@@ -31,6 +32,18 @@ interface TripData {
     expenses?: Array<{ id: string; [key: string]: unknown }>;
   };
 }
+
+const requireAdminDomain = async (): Promise<NextResponse<{ error: string }> | null> => {
+  const isAdmin = await isAdminDomain();
+  if (isAdmin) {
+    return null;
+  }
+
+  return NextResponse.json(
+    { error: 'Forbidden - admin domain required' },
+    { status: 403 }
+  );
+};
 
 const findRouteItem = (tripData: TripData, travelItemId: string) => {
   if (!tripData.travelData?.routes) return null;
@@ -124,6 +137,11 @@ function addLinkToTravelItem(travelItem: { costTrackingLinks?: Array<{ expenseId
 
 export async function POST(request: NextRequest) {
   try {
+    const forbidden = await requireAdminDomain();
+    if (forbidden) {
+      return forbidden;
+    }
+
     const body: MoveExpenseRequest = await request.json();
     const { tripId, expenseId, fromTravelItemId, toTravelItemId, toTravelItemType, description } = body;
 

--- a/src/app/api/travel-data/expense-links/route.ts
+++ b/src/app/api/travel-data/expense-links/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { loadUnifiedTripData, saveUnifiedTripData } from '@/app/lib/unifiedDataService';
+import { isAdminDomain } from '@/app/lib/server-domains';
 import { Transportation, TravelReference } from '@/app/types';
 
 interface LinkExpenseRequest {
@@ -47,6 +48,18 @@ interface TripData {
     expenses?: Array<{ id: string; [key: string]: unknown }>;
   };
 }
+
+const requireAdminDomain = async (): Promise<NextResponse<{ error: string }> | null> => {
+  const isAdmin = await isAdminDomain();
+  if (isAdmin) {
+    return null;
+  }
+
+  return NextResponse.json(
+    { error: 'Forbidden - admin domain required' },
+    { status: 403 }
+  );
+};
 
 const findRouteItem = (tripData: TripData, travelItemId: string) => {
   if (!tripData.travelData?.routes) return null;
@@ -150,6 +163,11 @@ function addLinkToTravelItem(travelItem: { costTrackingLinks?: Array<{ expenseId
 
 export async function POST(request: NextRequest) {
   try {
+    const forbidden = await requireAdminDomain();
+    if (forbidden) {
+      return forbidden;
+    }
+
     const body: LinkExpenseRequest = await request.json();
     const { tripId, expenseId, travelItemId, travelItemType, description } = body;
 
@@ -242,6 +260,11 @@ export async function POST(request: NextRequest) {
 
 export async function DELETE(request: NextRequest) {
   try {
+    const forbidden = await requireAdminDomain();
+    if (forbidden) {
+      return forbidden;
+    }
+
     const body: UnlinkExpenseRequest = await request.json();
     const { tripId, expenseId, travelItemId } = body;
 

--- a/src/app/lib/serverPrivacyUtils.ts
+++ b/src/app/lib/serverPrivacyUtils.ts
@@ -1,8 +1,9 @@
-import { Journey, Location, Transportation, JourneyPeriod } from '@/app/types';
+import { Accommodation, Journey, Location, Transportation, JourneyPeriod } from '@/app/types';
 
 interface TravelData {
   locations?: Location[];
   routes?: Transportation[];
+  accommodations?: Accommodation[];
   days?: JourneyPeriod[];
   [key: string]: unknown;
 }
@@ -83,6 +84,27 @@ export function filterTransportationForServer(
 }
 
 /**
+ * Filter accommodation data based on request context (server-side only)
+ */
+export function filterAccommodationForServer(
+  accommodation: Accommodation,
+  host: string | null
+): Accommodation {
+  const isAdmin = isAdminRequest(host);
+
+  if (isAdmin) {
+    return accommodation;
+  }
+
+  return {
+    ...accommodation,
+    accommodationData: accommodation.isAccommodationPublic ? accommodation.accommodationData : undefined,
+    isAccommodationPublic: undefined,
+    costTrackingLinks: undefined,
+  };
+}
+
+/**
  * Filter journey period data based on request context (server-side only)
  */
 export function filterJourneyPeriodForServer(
@@ -111,11 +133,15 @@ export function filterJourneyForServer(journey: Journey, host: string | null): J
   const filteredDays = journey.days.map(period => 
     filterJourneyPeriodForServer(period, host)
   );
+  const journeyWithAccommodations = journey as Journey & { accommodations?: Accommodation[] };
 
   return {
     ...journey,
+    accommodations: journeyWithAccommodations.accommodations?.map((accommodation: Accommodation) =>
+      filterAccommodationForServer(accommodation, host)
+    ),
     days: filteredDays,
-  };
+  } as Journey;
 }
 
 /**
@@ -134,6 +160,9 @@ export function filterTravelDataForServer(travelData: TravelData, host: string |
     const filteredJourney = filterJourneyForServer(travelData as unknown as Journey, host);
     return {
       ...filteredJourney,
+      accommodations: travelData.accommodations?.map((accommodation: Accommodation) =>
+        filterAccommodationForServer(accommodation, host)
+      ),
       instagramUsername: undefined
     } as TravelData;
   }
@@ -150,6 +179,12 @@ export function filterTravelDataForServer(travelData: TravelData, host: string |
   if (travelData.routes) {
     filteredData.routes = travelData.routes.map((route: Transportation) => 
       filterTransportationForServer(route, host)
+    );
+  }
+
+  if (travelData.accommodations) {
+    filteredData.accommodations = travelData.accommodations.map((accommodation: Accommodation) =>
+      filterAccommodationForServer(accommodation, host)
     );
   }
 


### PR DESCRIPTION
## Summary
- require the admin domain for legacy expense-link create/delete/move mutation routes
- keep top-level accommodation costTrackingLinks out of public travel-data responses
- add focused API and privacy regression tests

## Security findings
- 39e3eed014c08191b9b29a14bf245a5a: Unauthenticated expense-link mutation API
- 2f8647accf2c8191b265ff5fbf798948: Unauthenticated expense split data leak
- 0e251f07a24081918584b038a03d5ede: Unauthenticated sub-route expense unlinking
- d651655672a48191b91856b8bc5e30c2: Public expense-link APIs expose and alter cost references
- 775f68c6e0508191abee0d00154c7d9e: V5 migration exposes private expense links publicly
- 7060347e8e3c8191ae5aa3b5de7472a8: Unauthenticated split errors leak expense amounts

## Deferred
- 4bba9f744ef88191ad28dbc49376e2a1 needs a separate accommodations API authorization pass.

## Validation
- bun run test:unit -- src/app/__tests__/api/expense-links-auth.test.ts src/app/__tests__/lib/serverPrivacyUtils.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint