### PR TITLE
Harden calendar shadow privacy boundary

### DIFF
--- a/src/app/__tests__/lib/calendarPrivacy.test.ts
+++ b/src/app/__tests__/lib/calendarPrivacy.test.ts
@@ -1,0 +1,106 @@
+import { buildPublicCalendarTrip } from '@/app/lib/calendarPrivacy';
+import type { Trip } from '@/app/types';
+
+describe('calendar privacy helpers', () => {
+  it('removes private calendar-only details before public rendering', () => {
+    const trip: Trip = {
+      id: 'trip-1',
+      title: 'Private itinerary',
+      description: 'Test trip',
+      startDate: '2026-01-01',
+      endDate: '2026-01-05',
+      locations: [
+        {
+          id: 'loc-public',
+          name: 'Public City',
+          coordinates: [48.8566, 2.3522],
+          date: new Date('2026-01-01T00:00:00.000Z'),
+          endDate: new Date('2026-01-03T00:00:00.000Z'),
+          arrivalTime: '2026-01-01T08:30:00.000Z',
+          departureTime: '2026-01-03T21:00:00.000Z',
+          notes: 'Hotel door code 1234',
+          costTrackingLinks: [{ expenseId: 'expense-1' }],
+          accommodationData: 'Public hotel name',
+          isAccommodationPublic: true,
+        },
+        {
+          id: 'loc-private',
+          name: 'Private Stop',
+          coordinates: [50.8503, 4.3517],
+          date: new Date('2026-01-04T00:00:00.000Z'),
+          notes: '[PRIVATE] family address',
+        },
+      ],
+      routes: [
+        {
+          id: 'route-public',
+          type: 'train',
+          from: 'Public City',
+          to: 'Next City',
+          departureTime: '2026-01-03T21:00:00.000Z',
+          arrivalTime: '2026-01-03T23:00:00.000Z',
+          privateNotes: undefined,
+          costTrackingLinks: [{ expenseId: 'expense-2' }],
+          subRoutes: [
+            {
+              id: 'sub-route',
+              type: 'metro',
+              from: 'Station A',
+              to: 'Station B',
+              privateNotes: 'platform detail',
+              costTrackingLinks: [{ expenseId: 'expense-3' }],
+            },
+          ],
+        },
+        {
+          id: 'route-private',
+          type: 'car',
+          from: 'A',
+          to: 'B',
+          privateNotes: 'private pickup',
+        },
+      ],
+      accommodations: [
+        {
+          id: 'acc-private',
+          name: 'Private Hotel',
+          locationId: 'loc-public',
+          accommodationData: 'booking reference',
+          isAccommodationPublic: false,
+          costTrackingLinks: [{ expenseId: 'expense-4' }],
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+
+    const result = buildPublicCalendarTrip(trip);
+
+    expect(result.locations).toHaveLength(1);
+    expect(result.locations[0]).toMatchObject({
+      id: 'loc-public',
+      arrivalTime: undefined,
+      departureTime: undefined,
+      notes: undefined,
+      costTrackingLinks: undefined,
+      accommodationData: 'Public hotel name',
+      isAccommodationPublic: undefined,
+    });
+    expect(result.routes).toHaveLength(1);
+    expect(result.routes[0]).toMatchObject({
+      id: 'route-public',
+      departureTime: undefined,
+      arrivalTime: undefined,
+      privateNotes: undefined,
+      costTrackingLinks: undefined,
+    });
+    expect(result.routes[0].subRoutes?.[0]).toMatchObject({
+      privateNotes: undefined,
+      costTrackingLinks: undefined,
+    });
+    expect(result.accommodations[0]).toMatchObject({
+      accommodationData: undefined,
+      isAccommodationPublic: undefined,
+      costTrackingLinks: undefined,
+    });
+  });
+});

--- a/src/app/__tests__/lib/calendarPrivacy.test.ts
+++ b/src/app/__tests__/lib/calendarPrivacy.test.ts
@@ -22,6 +22,7 @@ describe('calendar privacy helpers', () => {
           costTrackingLinks: [{ expenseId: 'expense-1' }],
           accommodationData: 'Public hotel name',
           isAccommodationPublic: true,
+          accommodationIds: ['acc-private', 'acc-public'],
         },
         {
           id: 'loc-private',
@@ -100,6 +101,7 @@ describe('calendar privacy helpers', () => {
       costTrackingLinks: undefined,
       accommodationData: 'Public hotel name',
       isAccommodationPublic: undefined,
+      accommodationIds: undefined,
     });
     expect(result.routes).toHaveLength(1);
     expect(result.routes[0]).toMatchObject({

--- a/src/app/__tests__/lib/calendarPrivacy.test.ts
+++ b/src/app/__tests__/lib/calendarPrivacy.test.ts
@@ -30,6 +30,13 @@ describe('calendar privacy helpers', () => {
           date: new Date('2026-01-04T00:00:00.000Z'),
           notes: '[PRIVATE] family address',
         },
+        {
+          id: 'loc-private-lowercase',
+          name: 'Private Lowercase Stop',
+          coordinates: [51.5074, -0.1278],
+          date: new Date('2026-01-05T00:00:00.000Z'),
+          notes: '[private] backup address',
+        },
       ],
       routes: [
         {
@@ -70,6 +77,15 @@ describe('calendar privacy helpers', () => {
           costTrackingLinks: [{ expenseId: 'expense-4' }],
           createdAt: '2026-01-01T00:00:00.000Z',
         },
+        {
+          id: 'acc-public',
+          name: 'Public Hotel',
+          locationId: 'loc-public',
+          accommodationData: 'public booking note',
+          isAccommodationPublic: true,
+          costTrackingLinks: [{ expenseId: 'expense-5' }],
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
       ],
     };
 
@@ -97,8 +113,10 @@ describe('calendar privacy helpers', () => {
       privateNotes: undefined,
       costTrackingLinks: undefined,
     });
+    expect(result.accommodations).toHaveLength(1);
     expect(result.accommodations[0]).toMatchObject({
-      accommodationData: undefined,
+      id: 'acc-public',
+      accommodationData: 'public booking note',
       isAccommodationPublic: undefined,
       costTrackingLinks: undefined,
     });

--- a/src/app/__tests__/lib/server-domains.test.ts
+++ b/src/app/__tests__/lib/server-domains.test.ts
@@ -36,4 +36,10 @@ describe('server domain helpers', () => {
     expect(isAdminHost('tt-admin.attacker.example')).toBe(false);
     expect(isAdminHost('public.example.test:3000')).toBe(false);
   });
+
+  it('only accepts numeric ports after a configured admin host', () => {
+    expect(isAdminHost('admin.example.test:443.evil.example')).toBe(false);
+    expect(isAdminHost('admin.example.test:evil')).toBe(false);
+    expect(isAdminHost('admin.example.test:443')).toBe(true);
+  });
 });

--- a/src/app/__tests__/lib/server-domains.test.ts
+++ b/src/app/__tests__/lib/server-domains.test.ts
@@ -31,4 +31,9 @@ describe('server domain helpers', () => {
     expect(isAdminHost('admin.example.test:3000')).toBe(true);
     expect(isAdminHost('public.example.test')).toBe(false);
   });
+
+  it('does not treat admin-looking substrings as admin hosts', () => {
+    expect(isAdminHost('tt-admin.attacker.example')).toBe(false);
+    expect(isAdminHost('public.example.test:3000')).toBe(false);
+  });
 });

--- a/src/app/api/shadow-trips/[tripId]/route.ts
+++ b/src/app/api/shadow-trips/[tripId]/route.ts
@@ -6,6 +6,7 @@ import { ShadowTrip } from '@/app/types';
 import { loadUnifiedTripData } from '@/app/lib/unifiedDataService';
 import { UnifiedTripData } from '@/app/lib/dataMigration';
 import { getDataDir } from '@/app/lib/dataDirectory';
+import { isAdminHost } from '@/app/lib/server-domains';
 
 const DATA_DIR = getDataDir();
 const SHADOW_DATA_FILE = join(DATA_DIR, 'shadowTravelData.json');
@@ -69,7 +70,7 @@ export async function GET(
 
     // Check if user is admin (shadow trips are admin-only)
     const host = request.headers.get('host');
-    const isAdmin = host?.includes('tt-admin') || host?.includes('localhost');
+    const isAdmin = isAdminHost(host);
     
     if (!isAdmin) {
       return NextResponse.json(
@@ -132,7 +133,7 @@ export async function PUT(
 
     // Check if user is admin
     const host = request.headers.get('host');
-    const isAdmin = host?.includes('tt-admin') || host?.includes('localhost');
+    const isAdmin = isAdminHost(host);
     
     if (!isAdmin) {
       return NextResponse.json(
@@ -191,7 +192,7 @@ export async function DELETE(
 
     // Check if user is admin
     const host = request.headers.get('host');
-    const isAdmin = host?.includes('tt-admin') || host?.includes('localhost');
+    const isAdmin = isAdminHost(host);
     
     if (!isAdmin) {
       return NextResponse.json(

--- a/src/app/calendars/[tripId]/page.tsx
+++ b/src/app/calendars/[tripId]/page.tsx
@@ -2,10 +2,15 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { headers } from 'next/headers';
 import Link from 'next/link';
+import { join } from 'path';
+import { readFile } from 'fs/promises';
 import { TripCalendar } from '@/app/components/TripCalendar';
 import TripUpdates from '@/app/components/TripUpdates';
 import { loadUnifiedTripData } from '@/app/lib/unifiedDataService';
-import { Location, Transportation, Accommodation } from '@/app/types';
+import { getDataDir } from '@/app/lib/dataDirectory';
+import { buildPublicCalendarTrip } from '@/app/lib/calendarPrivacy';
+import { isAdminHost } from '@/app/lib/server-domains';
+import { Location, Transportation, Accommodation, ShadowTrip } from '@/app/types';
 import { normalizeUtcDateToLocalDay } from '@/app/lib/dateUtils';
 import { filterUpdatesForPublic } from '@/app/lib/updateFilters';
 import { SHADOW_LOCATION_PREFIX } from '@/app/lib/shadowConstants';
@@ -15,6 +20,22 @@ interface CalendarPageProps {
     tripId: string;
   }>;
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+const SHADOW_DATA_FILE = join(getDataDir(), 'shadowTravelData.json');
+
+async function loadShadowTrip(tripId: string): Promise<ShadowTrip | null> {
+  try {
+    const content = await readFile(SHADOW_DATA_FILE, 'utf-8');
+    const shadowTrips = JSON.parse(content) as Record<string, ShadowTrip>;
+    return shadowTrips[tripId] || null;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.error('Error loading calendar shadow data:', error);
+    }
+    return null;
+  }
 }
 
 export async function generateMetadata({
@@ -43,19 +64,25 @@ export async function generateMetadata({
 }
 
 async function loadTripDataWithShadow(tripId: string, isAdmin: boolean) {
+  const tripData = await loadUnifiedTripData(tripId);
+
+  if (!tripData) {
+    return null;
+  }
+
   if (isAdmin) {
     try {
-      // Try to load shadow data first
-      const headersList = await headers();
-      const host = headersList.get('host') || 'localhost:3000';
-      const protocol = headersList.get('x-forwarded-proto') || 'http';
-      const baseUrl = `${protocol}://${host}`;
-      const response = await fetch(`${baseUrl}/api/shadow-trips/${tripId}`, {
-        cache: 'no-store'
-      });
-      
-      if (response.ok) {
-        const shadowData = await response.json();
+      const shadowTrip = await loadShadowTrip(tripId);
+
+      if (shadowTrip) {
+        const shadowData = {
+          ...tripData,
+          shadowData: {
+            shadowLocations: shadowTrip.shadowLocations,
+            shadowRoutes: shadowTrip.shadowRoutes,
+            shadowAccommodations: shadowTrip.shadowAccommodations,
+          },
+        };
 
         // Build coverage from real plans and filter shadow items that overlap
         const realLocations: Location[] = shadowData.travelData?.locations || [];
@@ -159,7 +186,7 @@ async function loadTripDataWithShadow(tripId: string, isAdmin: boolean) {
   }
   
   // Fallback to regular data
-  return await loadUnifiedTripData(tripId);
+  return tripData;
 }
 
 export default async function TripCalendarPage({ params }: CalendarPageProps) {
@@ -168,7 +195,7 @@ export default async function TripCalendarPage({ params }: CalendarPageProps) {
   // Check if this is admin mode based on domain
   const headersList = await headers();
   const host = headersList.get('host');
-  const isAdmin = Boolean(host?.includes('tt-admin') || host?.includes('localhost'));
+  const isAdmin = isAdminHost(host);
 
   let tripData: Awaited<ReturnType<typeof loadTripDataWithShadow>>;
   try {
@@ -193,19 +220,7 @@ export default async function TripCalendarPage({ params }: CalendarPageProps) {
 
   // In admin/planning mode, show all data including shadow data
   // In public mode, filter for public locations only
-  const displayTrip = isAdmin ? trip : {
-    ...trip,
-    locations: trip.locations.filter((location: Location) => {
-      // Temporary workaround: check for [PRIVATE] in notes
-      // TODO: Replace with proper isPublic boolean field when Issue #28 is implemented
-      return !location.notes?.includes('[PRIVATE]');
-    }),
-    routes: trip.routes.filter((route: Transportation) => {
-      // Temporary workaround: filter out routes with private notes
-      // TODO: Replace with proper public/private route flags when Issue #28 is implemented
-      return !route.privateNotes;
-    })
-  };
+  const displayTrip = isAdmin ? trip : buildPublicCalendarTrip(trip);
 
   const updates = isAdmin
     ? tripData.publicUpdates

--- a/src/app/components/LocationPopup/LocationPopupModal.tsx
+++ b/src/app/components/LocationPopup/LocationPopupModal.tsx
@@ -25,12 +25,14 @@ interface LocationPopupModalProps {
   isOpen: boolean;
   onClose: () => void;
   data: LocationPopupData | null;
+  isAdminView?: boolean;
 }
 
 export default function LocationPopupModal({
   isOpen,
   onClose,
-  data
+  data,
+  isAdminView = false
 }: LocationPopupModalProps) {
   const isTransition = (data?.day.locations?.length ?? 0) > 1;
   const [activeTab, setActiveTab] = useState<'departure' | 'arrival'>('departure');
@@ -265,6 +267,7 @@ export default function LocationPopupModal({
           location={location}
           day={day}
           tripId={tripId}
+          isAdminView={isAdminView}
         />
 
         {/* Weather Section with Tabs for Transition Days */}

--- a/src/app/components/LocationPopup/TripContextSection.tsx
+++ b/src/app/components/LocationPopup/TripContextSection.tsx
@@ -222,6 +222,17 @@ export default function TripContextSection({
                 </>
               )}
             </>
+          ) : isTransition ? (
+            <>
+              <p>
+                <span className="font-medium">Departure:</span> {location.name}
+              </p>
+              {secondaryLocation && (
+                <p>
+                  <span className="font-medium">Arrival:</span> {secondaryLocation.name}
+                </p>
+              )}
+            </>
           ) : isAdminView ? (
             <p>
               <span className="font-medium">Stay:</span> {formatDateRange(location.date, location.endDate)}

--- a/src/app/components/LocationPopup/TripContextSection.tsx
+++ b/src/app/components/LocationPopup/TripContextSection.tsx
@@ -14,12 +14,13 @@ interface TripContextSectionProps {
   location: Location;
   day: JourneyDay;
   tripId: string;
+  isAdminView?: boolean;
 }
 
 export default function TripContextSection({
   location,
   day,
-  tripId: _tripId
+  isAdminView = false
 }: TripContextSectionProps) {
   // Check if this is a transition day (multiple locations)
   const isTransition = day.locations && day.locations.length > 1;
@@ -202,7 +203,7 @@ export default function TripContextSection({
         </h3>
         
         <div className="space-y-1 text-sm text-gray-700 dark:text-gray-300">
-          {isTransition ? (
+          {isAdminView && isTransition ? (
             <>
               <p>
                 <span className="font-medium">Departure from:</span> {location.name}
@@ -221,19 +222,23 @@ export default function TripContextSection({
                 </>
               )}
             </>
-          ) : (
+          ) : isAdminView ? (
             <p>
               <span className="font-medium">Stay:</span> {formatDateRange(location.date, location.endDate)}
             </p>
+          ) : (
+            <p>
+              <span className="font-medium">Location:</span> {location.name}
+            </p>
           )}
           
-          {location.arrivalTime && (
+          {isAdminView && location.arrivalTime && (
             <p>
               <span className="font-medium">Arrival:</span> {location.arrivalTime}
             </p>
           )}
           
-          {(location.notes || day.customNotes) && (
+          {isAdminView && (location.notes || day.customNotes) && (
             <div className="mt-2 pt-2 border-t border-gray-200 dark:border-gray-600 space-y-2">
               {location.notes && (
                 <p className="italic">{location.notes}</p>

--- a/src/app/components/LocationPopup/__tests__/TripContextSection.test.tsx
+++ b/src/app/components/LocationPopup/__tests__/TripContextSection.test.tsx
@@ -21,6 +21,19 @@ const day: JourneyDay = {
   customNotes: 'Private side trip details',
 };
 
+const otherLocation: Location = {
+  id: 'loc-2',
+  name: 'London',
+  coordinates: [51.5074, -0.1278],
+  date: new Date('2026-01-03T00:00:00.000Z'),
+  endDate: new Date('2026-01-05T00:00:00.000Z'),
+};
+
+const transitionDay: JourneyDay = {
+  ...day,
+  locations: [location, otherLocation],
+};
+
 describe('TripContextSection privacy', () => {
   it('hides detailed itinerary fields for public views', () => {
     render(<TripContextSection location={location} day={day} tripId="trip-1" />);
@@ -39,6 +52,30 @@ describe('TripContextSection privacy', () => {
     expect(screen.getByText(/Stay:/)).toBeInTheDocument();
     expect(screen.getByText(/Arrival:/)).toBeInTheDocument();
     expect(screen.getByText('2026-01-01T08:30:00.000Z')).toBeInTheDocument();
+    expect(screen.getByText('Hotel door code 1234')).toBeInTheDocument();
+    expect(screen.getByText('Private side trip details')).toBeInTheDocument();
+  });
+
+  it('shows public transition names without detailed itinerary fields', () => {
+    render(<TripContextSection location={location} day={transitionDay} tripId="trip-1" />);
+
+    expect(screen.getByText('Transition Day Details')).toBeInTheDocument();
+    expect(screen.getByText('Departure:')).toBeInTheDocument();
+    expect(screen.getByText('Arrival:')).toBeInTheDocument();
+    expect(screen.getByText('London')).toBeInTheDocument();
+    expect(screen.queryByText(/Stay period:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Arrival to:/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Hotel door code 1234')).not.toBeInTheDocument();
+    expect(screen.queryByText('Private side trip details')).not.toBeInTheDocument();
+  });
+
+  it('shows detailed transition fields for admin views', () => {
+    render(<TripContextSection location={location} day={transitionDay} tripId="trip-1" isAdminView />);
+
+    expect(screen.getByText('Transition Day Details')).toBeInTheDocument();
+    expect(screen.getByText(/Departure from:/)).toBeInTheDocument();
+    expect(screen.getByText(/Arrival to:/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Stay period:/)).toHaveLength(2);
     expect(screen.getByText('Hotel door code 1234')).toBeInTheDocument();
     expect(screen.getByText('Private side trip details')).toBeInTheDocument();
   });

--- a/src/app/components/LocationPopup/__tests__/TripContextSection.test.tsx
+++ b/src/app/components/LocationPopup/__tests__/TripContextSection.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import TripContextSection from '@/app/components/LocationPopup/TripContextSection';
+import type { JourneyDay, Location } from '@/app/types';
+
+const location: Location = {
+  id: 'loc-1',
+  name: 'Paris',
+  coordinates: [48.8566, 2.3522],
+  date: new Date('2026-01-01T00:00:00.000Z'),
+  endDate: new Date('2026-01-03T00:00:00.000Z'),
+  arrivalTime: '2026-01-01T08:30:00.000Z',
+  notes: 'Hotel door code 1234',
+};
+
+const day: JourneyDay = {
+  id: 'day-1',
+  title: 'Paris',
+  date: new Date('2026-01-01T00:00:00.000Z'),
+  endDate: new Date('2026-01-03T00:00:00.000Z'),
+  locations: [location],
+  customNotes: 'Private side trip details',
+};
+
+describe('TripContextSection privacy', () => {
+  it('hides detailed itinerary fields for public views', () => {
+    render(<TripContextSection location={location} day={day} tripId="trip-1" />);
+
+    expect(screen.getByText('Location:')).toBeInTheDocument();
+    expect(screen.getByText('Paris')).toBeInTheDocument();
+    expect(screen.queryByText(/Stay:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Arrival:/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Hotel door code 1234')).not.toBeInTheDocument();
+    expect(screen.queryByText('Private side trip details')).not.toBeInTheDocument();
+  });
+
+  it('shows detailed itinerary fields for admin views', () => {
+    render(<TripContextSection location={location} day={day} tripId="trip-1" isAdminView />);
+
+    expect(screen.getByText(/Stay:/)).toBeInTheDocument();
+    expect(screen.getByText(/Arrival:/)).toBeInTheDocument();
+    expect(screen.getByText('2026-01-01T08:30:00.000Z')).toBeInTheDocument();
+    expect(screen.getByText('Hotel door code 1234')).toBeInTheDocument();
+    expect(screen.getByText('Private side trip details')).toBeInTheDocument();
+  });
+});

--- a/src/app/components/TripCalendar/TripCalendar.tsx
+++ b/src/app/components/TripCalendar/TripCalendar.tsx
@@ -312,6 +312,7 @@ export default function TripCalendar({
         isOpen={isOpen}
         onClose={handlePopupClose}
         data={data}
+        isAdminView={planningMode}
       />
     </div>
   );

--- a/src/app/lib/calendarPrivacy.ts
+++ b/src/app/lib/calendarPrivacy.ts
@@ -12,6 +12,7 @@ export function sanitizeCalendarLocationForPublic(location: Location): Location 
     notes: undefined,
     accommodationData: location.isAccommodationPublic ? location.accommodationData : undefined,
     isAccommodationPublic: undefined,
+    accommodationIds: undefined,
     costTrackingLinks: undefined,
   };
 }

--- a/src/app/lib/calendarPrivacy.ts
+++ b/src/app/lib/calendarPrivacy.ts
@@ -1,0 +1,52 @@
+import { Location, Transportation, Trip } from '@/app/types';
+
+export function isPrivateCalendarLocation(location: Location): boolean {
+  return Boolean(location.notes?.includes('[PRIVATE]'));
+}
+
+export function sanitizeCalendarLocationForPublic(location: Location): Location {
+  return {
+    ...location,
+    arrivalTime: undefined,
+    departureTime: undefined,
+    notes: undefined,
+    accommodationData: location.isAccommodationPublic ? location.accommodationData : undefined,
+    isAccommodationPublic: undefined,
+    costTrackingLinks: undefined,
+  };
+}
+
+export function sanitizeCalendarRouteForPublic(route: Transportation): Transportation {
+  return {
+    ...route,
+    departureTime: undefined,
+    arrivalTime: undefined,
+    privateNotes: undefined,
+    costTrackingLinks: undefined,
+    subRoutes: route.subRoutes?.map(subRoute => ({
+      ...subRoute,
+      departureTime: undefined,
+      arrivalTime: undefined,
+      privateNotes: undefined,
+      costTrackingLinks: undefined,
+    })),
+  };
+}
+
+export function buildPublicCalendarTrip(trip: Trip): Trip {
+  return {
+    ...trip,
+    locations: trip.locations
+      .filter(location => !isPrivateCalendarLocation(location))
+      .map(sanitizeCalendarLocationForPublic),
+    routes: trip.routes
+      .filter(route => !route.privateNotes)
+      .map(sanitizeCalendarRouteForPublic),
+    accommodations: trip.accommodations.map(accommodation => ({
+      ...accommodation,
+      accommodationData: accommodation.isAccommodationPublic ? accommodation.accommodationData : undefined,
+      isAccommodationPublic: undefined,
+      costTrackingLinks: undefined,
+    })),
+  };
+}

--- a/src/app/lib/calendarPrivacy.ts
+++ b/src/app/lib/calendarPrivacy.ts
@@ -1,7 +1,7 @@
 import { Location, Transportation, Trip } from '@/app/types';
 
 export function isPrivateCalendarLocation(location: Location): boolean {
-  return Boolean(location.notes?.includes('[PRIVATE]'));
+  return Boolean(location.notes && /\[private\]/i.test(location.notes));
 }
 
 export function sanitizeCalendarLocationForPublic(location: Location): Location {
@@ -42,11 +42,12 @@ export function buildPublicCalendarTrip(trip: Trip): Trip {
     routes: trip.routes
       .filter(route => !route.privateNotes)
       .map(sanitizeCalendarRouteForPublic),
-    accommodations: trip.accommodations.map(accommodation => ({
-      ...accommodation,
-      accommodationData: accommodation.isAccommodationPublic ? accommodation.accommodationData : undefined,
-      isAccommodationPublic: undefined,
-      costTrackingLinks: undefined,
-    })),
+    accommodations: trip.accommodations
+      .filter(accommodation => accommodation.isAccommodationPublic)
+      .map(accommodation => ({
+        ...accommodation,
+        isAccommodationPublic: undefined,
+        costTrackingLinks: undefined,
+      })),
   };
 }

--- a/src/app/lib/server-domains.ts
+++ b/src/app/lib/server-domains.ts
@@ -8,21 +8,34 @@ export async function getCurrentDomain(): Promise<string> {
   return `${protocol}://${host}`;
 }
 
+function normalizeConfiguredHost(host: string): string {
+  return host.replace(/^https?:\/\//, '').toLowerCase().replace(/\.$/, '');
+}
+
+function hostMatchesConfiguredHost(host: string, configuredHost: string): boolean {
+  if (host === configuredHost) {
+    return true;
+  }
+
+  if (configuredHost.includes(':')) {
+    return false;
+  }
+
+  return new RegExp(`^${configuredHost.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:\\d+$`).test(host);
+}
+
 export function isAdminHost(host: string | null): boolean {
   if (!host) {
     return false;
   }
 
   // Use environment variable for admin domain
-  const adminDomain = process.env.ADMIN_DOMAIN
-    ?.replace(/^https?:\/\//, '')
-    .toLowerCase()
-    .replace(/\.$/, '');
+  const adminDomain = process.env.ADMIN_DOMAIN ? normalizeConfiguredHost(process.env.ADMIN_DOMAIN) : undefined;
   const normalizedHost = host.toLowerCase().replace(/\.$/, '');
 
   return Boolean(
-    (adminDomain && (normalizedHost === adminDomain || normalizedHost.startsWith(`${adminDomain}:`))) ||
-    (process.env.NODE_ENV !== 'production' && (normalizedHost === 'localhost' || normalizedHost.startsWith('localhost:')))
+    (adminDomain && hostMatchesConfiguredHost(normalizedHost, adminDomain)) ||
+    (process.env.NODE_ENV !== 'production' && hostMatchesConfiguredHost(normalizedHost, 'localhost'))
   );
 }
 

--- a/src/app/map/[id]/page.tsx
+++ b/src/app/map/[id]/page.tsx
@@ -11,6 +11,7 @@ import TripUpdates from '@/app/components/TripUpdates';
 import { filterUpdatesForPublic } from '@/app/lib/updateFilters';
 import { SHADOW_LOCATION_PREFIX } from '@/app/lib/shadowConstants';
 import { normalizeMapTravelData, toMapRouteSegment } from '@/app/lib/mapRouteTransform';
+import { isAdminHost } from '@/app/lib/server-domains';
 
 const toMapDateString = (value?: string | Date): string | undefined => {
   if (!value) return undefined;
@@ -209,7 +210,7 @@ export default async function MapPage({
   // Check if this is admin mode based on domain
   const headersList = await headers();
   const host = headersList.get('host');
-  const isAdmin = Boolean(host?.includes('tt-admin') || host?.includes('localhost'));
+  const isAdmin = isAdminHost(host);
   
   const travelData = await getTravelData(id, isAdmin);
   


### PR DESCRIPTION
## Summary
- load shadow calendar data directly from the data directory instead of fetching a Host-derived internal URL
- use exact admin host matching for calendar/map/shadow admin gates
- sanitize public calendar trip data and hide detailed itinerary popup fields outside admin/planning mode

## Security findings
- 02c3aa335b648191a80af1cbbba14eed
- 2bcf47948bbc8191ad18529bca2ebb0e

## Tests
- bun run test:unit -- src/app/__tests__/lib/calendarPrivacy.test.ts src/app/components/LocationPopup/__tests__/TripContextSection.test.tsx src/app/__tests__/lib/server-domains.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bunx eslint 'src/app/calendars/[tripId]/page.tsx' src/app/lib/calendarPrivacy.ts src/app/components/TripCalendar/TripCalendar.tsx src/app/components/LocationPopup/LocationPopupModal.tsx src/app/components/LocationPopup/TripContextSection.tsx 'src/app/api/shadow-trips/[tripId]/route.ts' 'src/app/map/[id]/page.tsx' src/app/__tests__/lib/calendarPrivacy.test.ts src/app/components/LocationPopup/__tests__/TripContextSection.test.tsx src/app/__tests__/lib/server-domains.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented privacy filtering for public calendars, automatically removing private locations, sensitive time details, notes, and cost-tracking information from public views.
  * Enhanced admin mode detection for accessing planning features and shadow trip data.

* **Tests**
  * Added test coverage for calendar privacy filtering and admin mode validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->