### PR TITLE
Allowlist public calendar client payload

### DIFF
--- a/src/app/__tests__/lib/calendarPrivacy.test.ts
+++ b/src/app/__tests__/lib/calendarPrivacy.test.ts
@@ -95,32 +95,178 @@ describe('calendar privacy helpers', () => {
     expect(result.locations).toHaveLength(1);
     expect(result.locations[0]).toMatchObject({
       id: 'loc-public',
-      arrivalTime: undefined,
-      departureTime: undefined,
-      notes: undefined,
-      costTrackingLinks: undefined,
       accommodationData: 'Public hotel name',
-      isAccommodationPublic: undefined,
-      accommodationIds: undefined,
     });
+    expect(result.locations[0]).not.toHaveProperty('arrivalTime');
+    expect(result.locations[0]).not.toHaveProperty('departureTime');
+    expect(result.locations[0]).not.toHaveProperty('notes');
+    expect(result.locations[0]).not.toHaveProperty('costTrackingLinks');
+    expect(result.locations[0]).not.toHaveProperty('isAccommodationPublic');
+    expect(result.locations[0]).not.toHaveProperty('accommodationIds');
     expect(result.routes).toHaveLength(1);
     expect(result.routes[0]).toMatchObject({
       id: 'route-public',
-      departureTime: undefined,
-      arrivalTime: undefined,
-      privateNotes: undefined,
-      costTrackingLinks: undefined,
     });
-    expect(result.routes[0].subRoutes?.[0]).toMatchObject({
-      privateNotes: undefined,
-      costTrackingLinks: undefined,
-    });
+    expect(result.routes[0]).not.toHaveProperty('departureTime');
+    expect(result.routes[0]).not.toHaveProperty('arrivalTime');
+    expect(result.routes[0]).not.toHaveProperty('privateNotes');
+    expect(result.routes[0]).not.toHaveProperty('costTrackingLinks');
+    expect(result.routes[0].subRoutes).toHaveLength(0);
     expect(result.accommodations).toHaveLength(1);
     expect(result.accommodations[0]).toMatchObject({
       id: 'acc-public',
       accommodationData: 'public booking note',
-      isAccommodationPublic: undefined,
-      costTrackingLinks: undefined,
     });
+    expect(result.accommodations[0]).not.toHaveProperty('isAccommodationPublic');
+    expect(result.accommodations[0]).not.toHaveProperty('costTrackingLinks');
+  });
+
+  it('builds a strict public calendar payload allowlist from trip-shaped unified data', () => {
+    const trip = {
+      id: 'trip-1',
+      title: 'Calendar trip',
+      description: 'Public description',
+      startDate: '2026-01-01',
+      endDate: '2026-01-02',
+      isArchived: false,
+      costData: {
+        ynabConfig: {
+          apiKey: 'SENTINEL_YNAB_TOKEN',
+        },
+        expenses: [{ notes: 'SENTINEL_COST_NOTES' }],
+      },
+      travelData: {
+        instagramUsername: 'SENTINEL_PRIVATE_INSTAGRAM',
+      },
+      publicUpdates: [{ message: 'SENTINEL_PUBLIC_UPDATE_FIELD' }],
+      shadowData: {
+        shadowLocations: [{ name: 'SENTINEL_SHADOW_LOCATION' }],
+      },
+      locations: [
+        {
+          id: 'loc-public',
+          name: 'Public City',
+          coordinates: [48.8566, 2.3522],
+          date: new Date('2026-01-01T00:00:00.000Z'),
+          notes: 'SENTINEL_PRIVATE_LOCATION_NOTES',
+          costTrackingLinks: [{ expenseId: 'SENTINEL_LOCATION_COST_LINK' }],
+          accommodationIds: ['SENTINEL_PRIVATE_ACCOMMODATION_ID'],
+          isAccommodationPublic: false,
+          accommodationData: 'SENTINEL_PRIVATE_LOCATION_ACCOMMODATION',
+          isReadOnly: true,
+          shadowData: 'SENTINEL_LOCATION_SHADOW_FIELD',
+          instagramPosts: [
+            {
+              id: 'ig-public',
+              url: 'https://instagram.com/p/public',
+              caption: 'Public caption',
+              privateCaptionDraft: 'SENTINEL_PRIVATE_POST_FIELD',
+            },
+          ],
+        },
+      ],
+      routes: [
+        {
+          id: 'route-public',
+          type: 'train',
+          from: 'Public City',
+          to: 'Next City',
+          departureTime: 'SENTINEL_ROUTE_DEPARTURE_TIME',
+          arrivalTime: 'SENTINEL_ROUTE_ARRIVAL_TIME',
+          privateNotes: undefined,
+          costTrackingLinks: [{ expenseId: 'SENTINEL_ROUTE_COST_LINK' }],
+          shadowData: 'SENTINEL_ROUTE_SHADOW_FIELD',
+          subRoutes: [
+            {
+              id: 'sub-route-public',
+              type: 'metro',
+              from: 'Station A',
+              to: 'Station B',
+              costTrackingLinks: [{ expenseId: 'SENTINEL_SUBROUTE_COST_LINK' }],
+              shadowData: 'SENTINEL_SUBROUTE_SHADOW_FIELD',
+            },
+          ],
+        },
+      ],
+      accommodations: [
+        {
+          id: 'acc-private',
+          name: 'SENTINEL_PRIVATE_ACCOMMODATION',
+          locationId: 'loc-public',
+          accommodationData: 'SENTINEL_PRIVATE_ACCOMMODATION_DATA',
+          isAccommodationPublic: false,
+          costTrackingLinks: [{ expenseId: 'SENTINEL_ACCOMMODATION_COST_LINK' }],
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          id: 'acc-public',
+          name: 'Public Hotel',
+          locationId: 'loc-public',
+          accommodationData: 'Public accommodation detail',
+          isAccommodationPublic: true,
+          costTrackingLinks: [{ expenseId: 'SENTINEL_PUBLIC_ACCOMMODATION_COST_LINK' }],
+          isReadOnly: true,
+          shadowData: 'SENTINEL_PUBLIC_ACCOMMODATION_SHADOW_FIELD',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    } as unknown as Trip;
+
+    const result = buildPublicCalendarTrip(trip);
+    const serialized = JSON.stringify(result);
+
+    expect(result).toEqual({
+      id: 'trip-1',
+      title: 'Calendar trip',
+      description: 'Public description',
+      startDate: '2026-01-01',
+      endDate: '2026-01-02',
+      isArchived: false,
+      locations: [
+        {
+          id: 'loc-public',
+          name: 'Public City',
+          coordinates: [48.8566, 2.3522],
+          date: new Date('2026-01-01T00:00:00.000Z'),
+          instagramPosts: [
+            {
+              id: 'ig-public',
+              url: 'https://instagram.com/p/public',
+              caption: 'Public caption',
+            },
+          ],
+        },
+      ],
+      routes: [
+        {
+          id: 'route-public',
+          type: 'train',
+          from: 'Public City',
+          to: 'Next City',
+          subRoutes: [
+            {
+              id: 'sub-route-public',
+              type: 'metro',
+              from: 'Station A',
+              to: 'Station B',
+            },
+          ],
+        },
+      ],
+      accommodations: [
+        {
+          id: 'acc-public',
+          name: 'Public Hotel',
+          locationId: 'loc-public',
+          accommodationData: 'Public accommodation detail',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    expect(serialized).not.toContain('SENTINEL_');
+    expect(serialized).not.toContain('costData');
+    expect(serialized).not.toContain('travelData');
+    expect(serialized).not.toContain('publicUpdates');
+    expect(serialized).not.toContain('shadowData');
   });
 });

--- a/src/app/lib/calendarPrivacy.ts
+++ b/src/app/lib/calendarPrivacy.ts
@@ -1,42 +1,98 @@
-import { Location, Transportation, Trip } from '@/app/types';
+import { Location, Transportation, TransportationSegment, Trip } from '@/app/types';
 
 export function isPrivateCalendarLocation(location: Location): boolean {
   return Boolean(location.notes && /\[private\]/i.test(location.notes));
 }
 
 export function sanitizeCalendarLocationForPublic(location: Location): Location {
-  return {
-    ...location,
-    arrivalTime: undefined,
-    departureTime: undefined,
-    notes: undefined,
-    accommodationData: location.isAccommodationPublic ? location.accommodationData : undefined,
-    isAccommodationPublic: undefined,
-    accommodationIds: undefined,
-    costTrackingLinks: undefined,
+  const publicLocation: Location = {
+    id: location.id,
+    name: location.name,
+    coordinates: location.coordinates,
+    date: location.date,
   };
+
+  if (location.endDate !== undefined) publicLocation.endDate = location.endDate;
+  if (location.duration !== undefined) publicLocation.duration = location.duration;
+  if (location.instagramPosts !== undefined) {
+    publicLocation.instagramPosts = location.instagramPosts.map(post => ({
+      id: post.id,
+      url: post.url,
+      caption: post.caption,
+    }));
+  }
+  if (location.tikTokPosts !== undefined) {
+    publicLocation.tikTokPosts = location.tikTokPosts.map(post => ({
+      id: post.id,
+      url: post.url,
+      caption: post.caption,
+    }));
+  }
+  if (location.blogPosts !== undefined) {
+    publicLocation.blogPosts = location.blogPosts.map(post => ({
+      id: post.id,
+      title: post.title,
+      url: post.url,
+      excerpt: post.excerpt,
+    }));
+  }
+  if (location.isAccommodationPublic && location.accommodationData !== undefined) {
+    publicLocation.accommodationData = location.accommodationData;
+  }
+  if (location.wikipediaRef !== undefined) publicLocation.wikipediaRef = location.wikipediaRef;
+
+  return publicLocation;
 }
 
 export function sanitizeCalendarRouteForPublic(route: Transportation): Transportation {
-  return {
-    ...route,
-    departureTime: undefined,
-    arrivalTime: undefined,
-    privateNotes: undefined,
-    costTrackingLinks: undefined,
-    subRoutes: route.subRoutes?.map(subRoute => ({
-      ...subRoute,
-      departureTime: undefined,
-      arrivalTime: undefined,
-      privateNotes: undefined,
-      costTrackingLinks: undefined,
-    })),
+  const publicRoute: Transportation = {
+    id: route.id,
+    type: route.type,
+    from: route.from,
+    to: route.to,
   };
+
+  if (route.distance !== undefined) publicRoute.distance = route.distance;
+  if (route.fromCoordinates !== undefined) publicRoute.fromCoordinates = route.fromCoordinates;
+  if (route.toCoordinates !== undefined) publicRoute.toCoordinates = route.toCoordinates;
+  if (route.routePoints !== undefined) publicRoute.routePoints = route.routePoints;
+  if (route.useManualRoutePoints !== undefined) publicRoute.useManualRoutePoints = route.useManualRoutePoints;
+  if (route.isReturn !== undefined) publicRoute.isReturn = route.isReturn;
+  if (route.subRoutes !== undefined) {
+    publicRoute.subRoutes = route.subRoutes
+      .filter(subRoute => !subRoute.privateNotes)
+      .map(subRoute => {
+        const publicSubRoute: TransportationSegment = {
+          id: subRoute.id,
+          type: subRoute.type,
+          from: subRoute.from,
+          to: subRoute.to,
+        };
+
+        if (subRoute.distance !== undefined) publicSubRoute.distance = subRoute.distance;
+        if (subRoute.fromCoordinates !== undefined) publicSubRoute.fromCoordinates = subRoute.fromCoordinates;
+        if (subRoute.toCoordinates !== undefined) publicSubRoute.toCoordinates = subRoute.toCoordinates;
+        if (subRoute.routePoints !== undefined) publicSubRoute.routePoints = subRoute.routePoints;
+        if (subRoute.useManualRoutePoints !== undefined) {
+          publicSubRoute.useManualRoutePoints = subRoute.useManualRoutePoints;
+        }
+        if (subRoute.isReturn !== undefined) publicSubRoute.isReturn = subRoute.isReturn;
+
+        return publicSubRoute;
+      });
+  }
+
+  return publicRoute;
 }
 
 export function buildPublicCalendarTrip(trip: Trip): Trip {
   return {
-    ...trip,
+    id: trip.id,
+    title: trip.title,
+    description: trip.description,
+    startDate: trip.startDate,
+    endDate: trip.endDate,
+    isArchived: trip.isArchived,
     locations: trip.locations
       .filter(location => !isPrivateCalendarLocation(location))
       .map(sanitizeCalendarLocationForPublic),
@@ -46,9 +102,12 @@ export function buildPublicCalendarTrip(trip: Trip): Trip {
     accommodations: trip.accommodations
       .filter(accommodation => accommodation.isAccommodationPublic)
       .map(accommodation => ({
-        ...accommodation,
-        isAccommodationPublic: undefined,
-        costTrackingLinks: undefined,
+        id: accommodation.id,
+        name: accommodation.name,
+        locationId: accommodation.locationId,
+        accommodationData: accommodation.accommodationData,
+        createdAt: accommodation.createdAt,
+        updatedAt: accommodation.updatedAt,
       })),
   };
 }


### PR DESCRIPTION
## Summary
- build public calendar client props from strict allowlists instead of object spreads
- drop unified/private extras such as costData, nested travelData, publicUpdates, shadowData, cost links, and private accommodation references
- add sentinel regression coverage for the critical calendar serialization leak

## Security finding
- 05f399ba725c81918a5d0ec5a2b29c70

## Tests
- bun run test:unit -- src/app/__tests__/lib/calendarPrivacy.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bunx eslint src/app/lib/calendarPrivacy.ts src/app/__tests__/lib/calendarPrivacy.test.ts