### PR TITLE
Render route preview popups with text nodes

### DIFF
--- a/src/app/admin/components/RoutePreviewMap.tsx
+++ b/src/app/admin/components/RoutePreviewMap.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Map, Marker } from 'leaflet';
+import type { Map, Marker } from 'leaflet';
 import { getRouteStyle, generateRoutePoints, calculateGreatCirclePoints, calculateSimpleArc } from '@/app/lib/routeUtils';
 import { attachMarkerKeyHandlers, escapeAttribute, formatCoordLabel } from '@/app/lib/mapIconUtils';
 import { Transportation } from '@/app/types';
@@ -32,6 +32,26 @@ const buildPreviewMarkerHtml = (label: string, color: string, text: string) => `
     ">${text}</div>
   </div>
 `;
+
+export function createRoutePreviewPopupContent(
+  label: 'Start' | 'End',
+  locationName: string,
+  coords: [number, number]
+): HTMLDivElement {
+  const container = document.createElement('div');
+
+  const title = document.createElement('strong');
+  title.textContent = `${label}: ${locationName}`;
+  container.appendChild(title);
+
+  container.appendChild(document.createElement('br'));
+
+  const coordinates = document.createElement('small');
+  coordinates.textContent = formatCoordLabel(coords);
+  container.appendChild(coordinates);
+
+  return container;
+}
 
 const RoutePreviewMap: React.FC<RoutePreviewProps> = ({ 
   from, 
@@ -187,11 +207,11 @@ const RoutePreviewMap: React.FC<RoutePreviewProps> = ({
         // Add markers - store references for popup updates
         const startMarker = L.marker(fromCoords, { icon: startIcon, keyboard: false })
           .addTo(map)
-          .bindPopup(`<strong>Start: ${from}</strong><br/><small>${formatCoordLabel(fromCoords)}</small>`);
+          .bindPopup(createRoutePreviewPopupContent('Start', from, fromCoords));
 
         const endMarker = L.marker(toCoords, { icon: endIcon, keyboard: false })
           .addTo(map)
-          .bindPopup(`<strong>End: ${to}</strong><br/><small>${formatCoordLabel(toCoords)}</small>`);
+          .bindPopup(createRoutePreviewPopupContent('End', to, toCoords));
 
         attachMarkerKeyHandlers(startMarker, () => startMarker.openPopup());
         attachMarkerKeyHandlers(endMarker, () => endMarker.openPopup());
@@ -255,8 +275,8 @@ const RoutePreviewMap: React.FC<RoutePreviewProps> = ({
   // Update popup content when location names change (without recreating map)
   useEffect(() => {
     if (startMarkerRef.current && endMarkerRef.current) {
-      const startPopupContent = `<strong>Start: ${from}</strong><br/><small>${formatCoordLabel(fromCoords)}</small>`;
-      const endPopupContent = `<strong>End: ${to}</strong><br/><small>${formatCoordLabel(toCoords)}</small>`;
+      const startPopupContent = createRoutePreviewPopupContent('Start', from, fromCoords);
+      const endPopupContent = createRoutePreviewPopupContent('End', to, toCoords);
       
       startMarkerRef.current.setPopupContent(startPopupContent);
       endMarkerRef.current.setPopupContent(endPopupContent);

--- a/src/app/admin/components/__tests__/RoutePreviewMap.popupContent.test.ts
+++ b/src/app/admin/components/__tests__/RoutePreviewMap.popupContent.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from '@jest/globals';
+import { createRoutePreviewPopupContent } from '@/app/admin/components/RoutePreviewMap';
+
+describe('createRoutePreviewPopupContent', () => {
+  it('treats route endpoint names as text, not popup HTML', () => {
+    const maliciousName = 'Paris <img src=x onerror="alert(1)"><script>alert(2)</script>';
+
+    const popupContent = createRoutePreviewPopupContent('Start', maliciousName, [48.8566, 2.3522]);
+
+    expect(popupContent.querySelector('img')).toBeNull();
+    expect(popupContent.querySelector('script')).toBeNull();
+    expect(popupContent.textContent).toContain(`Start: ${maliciousName}`);
+    expect(popupContent.innerHTML).not.toContain('<img');
+    expect(popupContent.innerHTML).not.toContain('<script>');
+  });
+});

--- a/src/app/admin/components/__tests__/RoutePreviewMap.popupContent.test.ts
+++ b/src/app/admin/components/__tests__/RoutePreviewMap.popupContent.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from '@jest/globals';
 import { createRoutePreviewPopupContent } from '@/app/admin/components/RoutePreviewMap';
 
 describe('createRoutePreviewPopupContent', () => {
+  it('renders normal route popup labels and coordinates', () => {
+    const popupContent = createRoutePreviewPopupContent('End', 'Brussels', [50.8503, 4.3517]);
+
+    expect(popupContent.querySelector('strong')?.textContent).toBe('End: Brussels');
+    expect(popupContent.querySelector('small')?.textContent).toBe('50.8503, 4.3517');
+  });
+
   it('treats route endpoint names as text, not popup HTML', () => {
     const maliciousName = 'Paris <img src=x onerror="alert(1)"><script>alert(2)</script>';
 


### PR DESCRIPTION
## Summary
- build Leaflet route preview popup content with DOM nodes and textContent
- replace HTML string bindPopup/setPopupContent calls for route from/to names
- add regression coverage for malicious route endpoint names

## Security finding
- 68a79c4528dc8191ab0292626752b05d

## Current-code validation
- travel-data POST/PUT/PATCH/DELETE already require admin domain on current main
- remaining valid issue was the RoutePreviewMap Leaflet popup HTML sink

## Tests
- bun run test:unit -- src/app/admin/components/__tests__/RoutePreviewMap.popupContent.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bunx eslint src/app/admin/components/RoutePreviewMap.tsx src/app/admin/components/__tests__/RoutePreviewMap.popupContent.test.ts