### PR TITLE
Load map shadow data without internal fetches

### DIFF
--- a/src/app/__tests__/lib/mapShadowData.test.ts
+++ b/src/app/__tests__/lib/mapShadowData.test.ts
@@ -1,0 +1,131 @@
+import { buildAdminMapTravelData, buildPublicMapTravelData } from '@/app/lib/mapShadowData';
+import { SHADOW_LOCATION_PREFIX } from '@/app/lib/shadowConstants';
+import type { ShadowTrip } from '@/app/types';
+import type { UnifiedTripData } from '@/app/lib/dataMigration';
+
+const baseTrip: UnifiedTripData = {
+  schemaVersion: 9,
+  id: 'trip-1',
+  title: 'Boundary Trip',
+  description: 'Trip with private and shadow data',
+  startDate: '2026-06-01',
+  endDate: '2026-06-10',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-02T00:00:00.000Z',
+  publicUpdates: [],
+  travelData: {
+    instagramUsername: 'private-handle',
+    locations: [
+      {
+        id: 'loc-real',
+        name: 'Real City',
+        coordinates: [48.8566, 2.3522],
+        date: new Date('2026-06-01T00:00:00.000Z'),
+        endDate: new Date('2026-06-03T00:00:00.000Z'),
+        accommodationIds: ['acc-private'],
+        costTrackingLinks: [{ expenseId: 'expense-1' }],
+      },
+    ],
+    routes: [
+      {
+        id: 'route-real',
+        type: 'train',
+        transportType: 'train',
+        from: 'Real City',
+        to: 'Next City',
+        fromCoordinates: [48.8566, 2.3522],
+        toCoordinates: [50.8503, 4.3517],
+        departureTime: '2026-06-03T08:00:00.000Z',
+        arrivalTime: '2026-06-03T10:00:00.000Z',
+        privateNotes: 'private platform',
+        costTrackingLinks: [{ expenseId: 'expense-2' }],
+      },
+    ],
+  },
+  accommodations: [
+    {
+      id: 'acc-private',
+      name: 'Private Hotel',
+      locationId: 'loc-real',
+      accommodationData: 'booking reference',
+      isAccommodationPublic: false,
+      createdAt: '2026-05-01T00:00:00.000Z',
+    },
+  ],
+};
+
+const shadowTrip: ShadowTrip = {
+  id: 'shadow-trip-1',
+  basedOn: 'trip-1',
+  createdAt: '2026-05-03T00:00:00.000Z',
+  shadowLocations: [
+    {
+      id: 'shadow-overlap',
+      name: 'Overlapping Shadow',
+      coordinates: [49, 3],
+      date: new Date('2026-06-02T00:00:00.000Z'),
+    },
+    {
+      id: 'shadow-visible',
+      name: 'Visible Shadow',
+      coordinates: [51.5074, -0.1278],
+      date: new Date('2026-06-05T00:00:00.000Z'),
+    },
+  ],
+  shadowRoutes: [
+    {
+      id: 'shadow-route-overlap',
+      type: 'bus',
+      from: 'Overlapping Shadow',
+      to: 'Hidden Shadow',
+      fromCoordinates: [49, 3],
+      toCoordinates: [50, 4],
+      departureTime: '2026-06-03T09:00:00.000Z',
+      arrivalTime: '2026-06-03T11:00:00.000Z',
+      privateNotes: 'overlapping shadow route note',
+    },
+    {
+      id: 'shadow-route',
+      type: 'plane',
+      from: 'Visible Shadow',
+      to: 'Later Shadow',
+      fromCoordinates: [51.5074, -0.1278],
+      toCoordinates: [52.52, 13.405],
+      departureTime: '2026-06-06T08:00:00.000Z',
+      arrivalTime: '2026-06-06T10:00:00.000Z',
+      privateNotes: 'shadow route note',
+    },
+  ],
+  shadowAccommodations: [],
+};
+
+describe('map shadow data boundary', () => {
+  it('builds public map data without shadow or admin-only route fields', () => {
+    const result = buildPublicMapTravelData(baseTrip);
+    const serialized = JSON.stringify(result);
+
+    expect(result.locations.map(location => location.name)).toEqual(['Real City']);
+    expect(result.routes.map(route => route.id)).toEqual(['route-real']);
+    expect(result.routes[0].notes).toBe('');
+    expect(serialized).not.toContain(SHADOW_LOCATION_PREFIX);
+    expect(serialized).not.toContain('private platform');
+    expect(serialized).not.toContain('costTrackingLinks');
+    expect(serialized).not.toContain('accommodationIds');
+    expect(serialized).not.toContain('private-handle');
+  });
+
+  it('builds admin map data with non-overlapping shadow plans', () => {
+    const result = buildAdminMapTravelData(baseTrip, shadowTrip);
+
+    expect(result.locations.map(location => location.name)).toEqual([
+      'Real City',
+      `${SHADOW_LOCATION_PREFIX} Visible Shadow`,
+    ]);
+    expect(result.routes.map(route => route.from)).toEqual([
+      'Real City',
+      `${SHADOW_LOCATION_PREFIX} Visible Shadow`,
+    ]);
+    expect(result.routes.map(route => route.id)).not.toContain('shadow-route-overlap');
+    expect(JSON.stringify(result)).not.toContain('overlapping shadow route note');
+  });
+});

--- a/src/app/calendars/[tripId]/page.tsx
+++ b/src/app/calendars/[tripId]/page.tsx
@@ -2,16 +2,14 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { headers } from 'next/headers';
 import Link from 'next/link';
-import { join } from 'path';
-import { readFile } from 'fs/promises';
 import { TripCalendar } from '@/app/components/TripCalendar';
 import TripUpdates from '@/app/components/TripUpdates';
 import { loadUnifiedTripData } from '@/app/lib/unifiedDataService';
-import { getDataDir } from '@/app/lib/dataDirectory';
 import { buildPublicCalendarTrip } from '@/app/lib/calendarPrivacy';
 import { isAdminHost } from '@/app/lib/server-domains';
-import { Location, Transportation, Accommodation, ShadowTrip } from '@/app/types';
-import { normalizeUtcDateToLocalDay } from '@/app/lib/dateUtils';
+import { loadShadowTrip } from '@/app/lib/shadowTripStorage';
+import { filterNonOverlappingShadowPlans } from '@/app/lib/mapShadowData';
+import { Location, Transportation, Accommodation } from '@/app/types';
 import { filterUpdatesForPublic } from '@/app/lib/updateFilters';
 import { SHADOW_LOCATION_PREFIX } from '@/app/lib/shadowConstants';
 
@@ -20,22 +18,6 @@ interface CalendarPageProps {
     tripId: string;
   }>;
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
-}
-
-const SHADOW_DATA_FILE = join(getDataDir(), 'shadowTravelData.json');
-
-async function loadShadowTrip(tripId: string): Promise<ShadowTrip | null> {
-  try {
-    const content = await readFile(SHADOW_DATA_FILE, 'utf-8');
-    const shadowTrips = JSON.parse(content) as Record<string, ShadowTrip>;
-    return shadowTrips[tripId] || null;
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code !== 'ENOENT') {
-      console.error('Error loading calendar shadow data:', error);
-    }
-    return null;
-  }
 }
 
 export async function generateMetadata({
@@ -90,58 +72,11 @@ async function loadTripDataWithShadow(tripId: string, isAdmin: boolean) {
         const shadowLocations: Location[] = shadowData.shadowData?.shadowLocations || [];
         const shadowRoutes: Transportation[] = shadowData.shadowData?.shadowRoutes || [];
 
-        const toStartOfDay = (d: Date) => {
-          const normalized = normalizeUtcDateToLocalDay(d) || new Date(d);
-          normalized.setHours(0, 0, 0, 0);
-          return normalized.getTime();
-        };
-        const toEndOfDay = (d: Date) => {
-          const normalized = normalizeUtcDateToLocalDay(d) || new Date(d);
-          normalized.setHours(23, 59, 59, 999);
-          return normalized.getTime();
-        };
-        const safeDate = (value?: string | Date) => {
-          if (!value) return null;
-          const d = value instanceof Date ? value : new Date(value);
-          return isNaN(d.getTime()) ? null : d;
-        };
-
-        type Interval = { start: number; end: number };
-        const realIntervals: Interval[] = [];
-        // Real locations coverage
-        for (const loc of realLocations) {
-          const startDate = safeDate((loc as any).date); // eslint-disable-line @typescript-eslint/no-explicit-any
-          const endDate = safeDate((loc as any).endDate || (loc as any).date); // eslint-disable-line @typescript-eslint/no-explicit-any
-          if (startDate && endDate) {
-            realIntervals.push({ start: toStartOfDay(startDate), end: toEndOfDay(endDate) });
-          }
-        }
-        // Real routes coverage
-        for (const route of realRoutes) {
-          const dep = safeDate((route as any).departureTime); // eslint-disable-line @typescript-eslint/no-explicit-any
-          const arr = safeDate((route as any).arrivalTime || (route as any).departureTime); // eslint-disable-line @typescript-eslint/no-explicit-any
-          if (dep && arr) {
-            realIntervals.push({ start: toStartOfDay(dep), end: toEndOfDay(arr) });
-          }
-        }
-        const overlaps = (start: number, end: number) => realIntervals.some(i => start <= i.end && end >= i.start);
-
-        const filteredShadowLocations: Location[] = shadowLocations.filter(loc => {
-          const startDate = safeDate((loc as any).date); // eslint-disable-line @typescript-eslint/no-explicit-any
-          const endDate = safeDate((loc as any).endDate || (loc as any).date); // eslint-disable-line @typescript-eslint/no-explicit-any
-          if (!startDate || !endDate) return true;
-          const s = toStartOfDay(startDate);
-          const e = toEndOfDay(endDate);
-          return !overlaps(s, e);
-        });
-
-        const filteredShadowRoutes: Transportation[] = shadowRoutes.filter(route => {
-          const dep = safeDate((route as any).departureTime); // eslint-disable-line @typescript-eslint/no-explicit-any
-          const arr = safeDate((route as any).arrivalTime || (route as any).departureTime); // eslint-disable-line @typescript-eslint/no-explicit-any
-          if (!dep || !arr) return true;
-          const s = toStartOfDay(dep);
-          const e = toEndOfDay(arr);
-          return !overlaps(s, e);
+        const { filteredShadowLocations, filteredShadowRoutes } = filterNonOverlappingShadowPlans({
+          realLocations,
+          realRoutes,
+          shadowLocations,
+          shadowRoutes,
         });
 
         // Merge real data with shadow data

--- a/src/app/lib/mapShadowData.ts
+++ b/src/app/lib/mapShadowData.ts
@@ -1,0 +1,204 @@
+import { formatLocalDateInput, parseDateAsLocalDay } from '@/app/lib/localDateUtils';
+import { filterTravelDataForServer } from '@/app/lib/serverPrivacyUtils';
+import { SHADOW_LOCATION_PREFIX } from '@/app/lib/shadowConstants';
+import { normalizeMapTravelData, toMapRouteSegment } from '@/app/lib/mapRouteTransform';
+import { loadUnifiedTripData } from '@/app/lib/unifiedDataService';
+import { loadShadowTrip } from '@/app/lib/shadowTripStorage';
+import type { UnifiedTripData } from '@/app/lib/dataMigration';
+import type { JourneyPeriod, Location, MapTravelData, ShadowTrip, Transportation } from '@/app/types';
+
+type TravelDataResponse = {
+  id: string;
+  title: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  createdAt?: string;
+  instagramUsername?: string;
+  locations: Location[];
+  routes: Transportation[];
+  days?: JourneyPeriod[];
+  accommodations: UnifiedTripData['accommodations'];
+  publicUpdates: UnifiedTripData['publicUpdates'];
+};
+
+type Interval = { start: number; end: number };
+
+const toMapDateString = (value?: string | Date): string | undefined => {
+  if (!value) return undefined;
+  return formatLocalDateInput(value) || undefined;
+};
+
+const safeDate = (value?: string | Date): Date | null => {
+  return parseDateAsLocalDay(value);
+};
+
+const toStartOfDay = (date: Date): number => {
+  const normalized = new Date(date);
+  normalized.setHours(0, 0, 0, 0);
+  return normalized.getTime();
+};
+
+const toEndOfDay = (date: Date): number => {
+  const normalized = new Date(date);
+  normalized.setHours(23, 59, 59, 999);
+  return normalized.getTime();
+};
+
+const locationInterval = (location: Location): Interval | null => {
+  const startDate = safeDate(location.date);
+  const endDate = safeDate(location.endDate || location.date);
+  if (!startDate || !endDate) return null;
+  return { start: toStartOfDay(startDate), end: toEndOfDay(endDate) };
+};
+
+const routeInterval = (route: Transportation): Interval | null => {
+  const startDate = safeDate(route.departureTime);
+  const endDate = safeDate(route.arrivalTime || route.departureTime);
+  if (!startDate || !endDate) return null;
+  return { start: toStartOfDay(startDate), end: toEndOfDay(endDate) };
+};
+
+const overlapsAny = (interval: Interval, intervals: Interval[]): boolean =>
+  intervals.some(candidate => interval.start <= candidate.end && interval.end >= candidate.start);
+
+export function filterNonOverlappingShadowPlans({
+  realLocations,
+  realRoutes,
+  shadowLocations,
+  shadowRoutes,
+}: {
+  realLocations: Location[];
+  realRoutes: Transportation[];
+  shadowLocations: Location[];
+  shadowRoutes: Transportation[];
+}): {
+  filteredShadowLocations: Location[];
+  filteredShadowRoutes: Transportation[];
+} {
+  const realIntervals = [
+    ...realLocations.map(locationInterval).filter((interval): interval is Interval => interval !== null),
+    ...realRoutes.map(routeInterval).filter((interval): interval is Interval => interval !== null)
+  ];
+
+  return {
+    filteredShadowLocations: shadowLocations.filter(location => {
+      const interval = locationInterval(location);
+      return !interval || !overlapsAny(interval, realIntervals);
+    }),
+    filteredShadowRoutes: shadowRoutes.filter(route => {
+      const interval = routeInterval(route);
+      return !interval || !overlapsAny(interval, realIntervals);
+    })
+  };
+}
+
+export function toTravelDataResponse(unifiedData: UnifiedTripData): TravelDataResponse {
+  return {
+    id: unifiedData.id,
+    title: unifiedData.title,
+    description: unifiedData.description,
+    startDate: unifiedData.startDate,
+    endDate: unifiedData.endDate,
+    createdAt: unifiedData.createdAt,
+    instagramUsername: unifiedData.travelData?.instagramUsername,
+    locations: unifiedData.travelData?.locations || [],
+    routes: unifiedData.travelData?.routes || [],
+    days: unifiedData.travelData?.days,
+    accommodations: unifiedData.accommodations || [],
+    publicUpdates: unifiedData.publicUpdates || []
+  };
+}
+
+export function buildPublicMapTravelData(unifiedData: UnifiedTripData): MapTravelData {
+  const publicTravelData = filterTravelDataForServer(toTravelDataResponse(unifiedData), null) as TravelDataResponse;
+  return normalizeMapTravelData(publicTravelData);
+}
+
+export function buildAdminMapTravelData(
+  unifiedData: UnifiedTripData,
+  shadowTrip: ShadowTrip | null
+): MapTravelData {
+  const realLocations: Location[] = unifiedData.travelData?.locations || [];
+  const realRoutes: Transportation[] = unifiedData.travelData?.routes || [];
+  const shadowLocations: Location[] = shadowTrip?.shadowLocations || [];
+  const shadowRoutes: Transportation[] = shadowTrip?.shadowRoutes || [];
+
+  const { filteredShadowLocations, filteredShadowRoutes } = filterNonOverlappingShadowPlans({
+    realLocations,
+    realRoutes,
+    shadowLocations,
+    shadowRoutes,
+  });
+
+  const transformedData: MapTravelData = {
+    id: unifiedData.id,
+    title: unifiedData.title,
+    description: unifiedData.description,
+    startDate: unifiedData.startDate,
+    endDate: unifiedData.endDate,
+    createdAt: unifiedData.createdAt,
+    publicUpdates: unifiedData.publicUpdates || [],
+    locations: [
+      ...realLocations.map(location => ({
+        id: location.id,
+        name: location.name,
+        coordinates: location.coordinates,
+        date: toMapDateString(location.date) ?? '',
+        endDate: toMapDateString(location.endDate),
+        notes: location.notes,
+        wikipediaRef: location.wikipediaRef,
+        instagramPosts: location.instagramPosts,
+        tikTokPosts: location.tikTokPosts,
+        blogPosts: location.blogPosts,
+      })),
+      ...filteredShadowLocations.map(location => ({
+        id: location.id,
+        name: `${SHADOW_LOCATION_PREFIX} ${location.name}`,
+        coordinates: location.coordinates,
+        date: toMapDateString(location.date) ?? '',
+        endDate: toMapDateString(location.endDate),
+        notes: location.notes,
+        wikipediaRef: location.wikipediaRef,
+        instagramPosts: location.instagramPosts,
+        tikTokPosts: location.tikTokPosts,
+        blogPosts: location.blogPosts,
+      }))
+    ],
+    routes: [
+      ...realRoutes.map(route => toMapRouteSegment(route)),
+      ...filteredShadowRoutes.map(route => {
+        const baseRoute = toMapRouteSegment(route);
+        return {
+          ...baseRoute,
+          from: `${SHADOW_LOCATION_PREFIX} ${route.from}`,
+          to: `${SHADOW_LOCATION_PREFIX} ${route.to}`,
+          subRoutes: baseRoute.subRoutes?.map(segment => ({
+            ...segment,
+            from: `${SHADOW_LOCATION_PREFIX} ${segment.from}`,
+            to: `${SHADOW_LOCATION_PREFIX} ${segment.to}`
+          }))
+        };
+      })
+    ]
+  };
+
+  return normalizeMapTravelData(transformedData);
+}
+
+export async function loadMapTravelDataForServer(
+  tripId: string,
+  isAdmin: boolean
+): Promise<MapTravelData | null> {
+  const unifiedData = await loadUnifiedTripData(tripId);
+  if (!unifiedData) {
+    return null;
+  }
+
+  if (!isAdmin) {
+    return buildPublicMapTravelData(unifiedData);
+  }
+
+  const shadowTrip = await loadShadowTrip(tripId);
+  return buildAdminMapTravelData(unifiedData, shadowTrip);
+}

--- a/src/app/lib/shadowTripStorage.ts
+++ b/src/app/lib/shadowTripStorage.ts
@@ -1,0 +1,20 @@
+import { join } from 'path';
+import { readFile } from 'fs/promises';
+import { getDataDir } from '@/app/lib/dataDirectory';
+import type { ShadowTrip } from '@/app/types';
+
+const SHADOW_DATA_FILE = join(getDataDir(), 'shadowTravelData.json');
+
+export async function loadShadowTrip(tripId: string): Promise<ShadowTrip | null> {
+  try {
+    const content = await readFile(SHADOW_DATA_FILE, 'utf-8');
+    const shadowTrips = JSON.parse(content) as Record<string, ShadowTrip>;
+    return shadowTrips[tripId] || null;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      console.error('Error loading shadow data:', error);
+    }
+    return null;
+  }
+}

--- a/src/app/map/[id]/page.tsx
+++ b/src/app/map/[id]/page.tsx
@@ -1,179 +1,19 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { headers } from 'next/headers';
-import { getDomainConfig } from '@/app/lib/domains';
 import EmbeddableMap from './components/EmbeddableMap';
-import { formatDateRange, formatUtcDate, normalizeUtcDateToLocalDay } from '@/app/lib/dateUtils';
-import { Location, Transportation, type MapTravelData } from '@/app/types';
+import { formatDateRange, formatUtcDate } from '@/app/lib/dateUtils';
 import InstagramIcon from '@/app/components/icons/InstagramIcon';
 import TikTokIcon from '@/app/components/icons/TikTokIcon';
 import TripUpdates from '@/app/components/TripUpdates';
 import { filterUpdatesForPublic } from '@/app/lib/updateFilters';
 import { SHADOW_LOCATION_PREFIX } from '@/app/lib/shadowConstants';
-import { normalizeMapTravelData, toMapRouteSegment } from '@/app/lib/mapRouteTransform';
 import { isAdminHost } from '@/app/lib/server-domains';
-
-const toMapDateString = (value?: string | Date): string | undefined => {
-  if (!value) return undefined;
-  return value instanceof Date ? value.toISOString().slice(0, 10) : value;
-};
-
-async function getTravelData(id: string, isAdmin: boolean = false): Promise<MapTravelData | null> {
-  try {
-    const { embedDomain } = getDomainConfig();
-    const baseUrl = embedDomain || 'http://localhost:3000';
-    
-    // In admin mode, try to load shadow data first, fallback to regular data
-    if (isAdmin) {
-      try {
-        const shadowResponse = await fetch(`${baseUrl}/api/shadow-trips/${id}`, {
-          cache: 'no-store'
-        });
-        
-        if (shadowResponse.ok) {
-          const shadowData = await shadowResponse.json();
-
-          // Build coverage from real plans and filter shadow items that overlap
-          const realLocations: Location[] = shadowData.travelData?.locations || [];
-          const realRoutes: Transportation[] = shadowData.travelData?.routes || [];
-          const shadowLocations: Location[] = shadowData.shadowData?.shadowLocations || [];
-          const shadowRoutes: Transportation[] = shadowData.shadowData?.shadowRoutes || [];
-
-          const toStartOfDay = (d: Date) => {
-            const normalized = normalizeUtcDateToLocalDay(d) || new Date(d);
-            normalized.setHours(0, 0, 0, 0);
-            return normalized.getTime();
-          };
-          const toEndOfDay = (d: Date) => {
-            const normalized = normalizeUtcDateToLocalDay(d) || new Date(d);
-            normalized.setHours(23, 59, 59, 999);
-            return normalized.getTime();
-          };
-          const safeDate = (value?: string | Date) => {
-            if (!value) return null;
-            const d = value instanceof Date ? value : new Date(value);
-            return isNaN(d.getTime()) ? null : d;
-          };
-
-          type Interval = { start: number; end: number };
-          const realIntervals: Interval[] = [];
-          // Real locations coverage
-          for (const loc of realLocations) {
-            const startDate = safeDate((loc as any).date); // eslint-disable-line @typescript-eslint/no-explicit-any
-            const endDate = safeDate((loc as any).endDate || (loc as any).date); // eslint-disable-line @typescript-eslint/no-explicit-any
-            if (startDate && endDate) {
-              realIntervals.push({ start: toStartOfDay(startDate), end: toEndOfDay(endDate) });
-            }
-          }
-          // Real routes coverage
-          for (const route of realRoutes) {
-            const dep = safeDate((route as any).departureTime); // eslint-disable-line @typescript-eslint/no-explicit-any
-            const arr = safeDate((route as any).arrivalTime || (route as any).departureTime); // eslint-disable-line @typescript-eslint/no-explicit-any
-            if (dep && arr) {
-              realIntervals.push({ start: toStartOfDay(dep), end: toEndOfDay(arr) });
-            }
-          }
-          const overlaps = (start: number, end: number) => realIntervals.some(i => start <= i.end && end >= i.start);
-
-          const filteredShadowLocations: Location[] = shadowLocations.filter(loc => {
-            const startDate = safeDate((loc as any).date); // eslint-disable-line @typescript-eslint/no-explicit-any
-            const endDate = safeDate((loc as any).endDate || (loc as any).date); // eslint-disable-line @typescript-eslint/no-explicit-any
-            if (!startDate || !endDate) return true;
-            const s = toStartOfDay(startDate);
-            const e = toEndOfDay(endDate);
-            return !overlaps(s, e);
-          });
-
-          const filteredShadowRoutes: Transportation[] = shadowRoutes.filter(route => {
-            const dep = safeDate((route as any).departureTime); // eslint-disable-line @typescript-eslint/no-explicit-any
-            const arr = safeDate((route as any).arrivalTime || (route as any).departureTime); // eslint-disable-line @typescript-eslint/no-explicit-any
-            if (!dep || !arr) return true;
-            const s = toStartOfDay(dep);
-            const e = toEndOfDay(arr);
-            return !overlaps(s, e);
-          });
-
-          // Transform shadow data to TravelData format
-          const transformedData: MapTravelData = {
-            id: shadowData.id,
-            title: shadowData.title,
-            description: shadowData.description,
-            startDate: shadowData.startDate,
-            endDate: shadowData.endDate,
-            createdAt: shadowData.createdAt,
-            publicUpdates: shadowData.publicUpdates || [],
-            // Merge real locations with shadow locations
-            locations: [
-              ...(shadowData.travelData?.locations || []).map((loc: Location) => ({
-                id: loc.id,
-                name: loc.name,
-                coordinates: loc.coordinates,
-                date: toMapDateString(loc.date) ?? '',
-                endDate: toMapDateString(loc.endDate),
-                notes: loc.notes,
-                wikipediaRef: loc.wikipediaRef,
-                instagramPosts: loc.instagramPosts,
-                tikTokPosts: loc.tikTokPosts,
-                blogPosts: loc.blogPosts,
-              })),
-              ...filteredShadowLocations.map((loc: Location) => ({
-                id: loc.id,
-                name: `${SHADOW_LOCATION_PREFIX} ${loc.name}`, // Prefix shadow locations
-                coordinates: loc.coordinates,
-                date: toMapDateString(loc.date) ?? '',
-                endDate: toMapDateString(loc.endDate),
-                notes: loc.notes,
-                wikipediaRef: loc.wikipediaRef,
-                instagramPosts: loc.instagramPosts,
-                tikTokPosts: loc.tikTokPosts,
-                blogPosts: loc.blogPosts,
-              }))
-            ],
-            // Merge real routes with shadow routes
-            routes: [
-              ...(shadowData.travelData?.routes || []).map((route: Transportation) => toMapRouteSegment(route)),
-              ...filteredShadowRoutes.map((route: Transportation) => {
-                const baseRoute = toMapRouteSegment(route);
-                return {
-                  ...baseRoute,
-                  from: `${SHADOW_LOCATION_PREFIX} ${route.from}`,
-                  to: `${SHADOW_LOCATION_PREFIX} ${route.to}`,
-                  subRoutes: baseRoute.subRoutes?.map(segment => ({
-                    ...segment,
-                    from: `${SHADOW_LOCATION_PREFIX} ${segment.from}`,
-                    to: `${SHADOW_LOCATION_PREFIX} ${segment.to}`
-                  }))
-                };
-              })
-            ]
-          };
-          
-          return normalizeMapTravelData(transformedData);
-        }
-      } catch {
-        console.log('Shadow data not available, falling back to regular data');
-      }
-    }
-    
-    const response = await fetch(`${baseUrl}/api/travel-data?id=${id}`, {
-      cache: 'no-store' // Always fetch fresh data
-    });
-    
-    if (!response.ok) {
-      return null;
-    }
-    
-    const rawTravelData = await response.json();
-    return normalizeMapTravelData(rawTravelData);
-  } catch (error) {
-    console.error('Error fetching travel data:', error);
-    return null;
-  }
-}
+import { loadMapTravelDataForServer } from '@/app/lib/mapShadowData';
 
 export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
   const { id } = await params;
-  const travelData = await getTravelData(id);
+  const travelData = await loadMapTravelDataForServer(id, false);
   
   if (!travelData) {
     return {
@@ -212,7 +52,7 @@ export default async function MapPage({
   const host = headersList.get('host');
   const isAdmin = isAdminHost(host);
   
-  const travelData = await getTravelData(id, isAdmin);
+  const travelData = await loadMapTravelDataForServer(id, isAdmin);
   
   if (!travelData) {
     notFound();


### PR DESCRIPTION
## Summary
- replace map page server-side self-fetches with direct unified-data and shadow-store loading
- share direct shadow-trip storage with the calendar page
- keep public map data on the server privacy path while admin map data may merge non-overlapping shadow plans

## Security finding
- 275f2668d6008191bb3ab7473a7248a5

## Tests
- bun run test:unit -- src/app/__tests__/lib/mapShadowData.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bunx eslint 'src/app/map/[id]/page.tsx' 'src/app/calendars/[tripId]/page.tsx' src/app/lib/mapShadowData.ts src/app/lib/shadowTripStorage.ts src/app/__tests__/lib/mapShadowData.test.ts
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shadow trip data management enabling admins to plan trips separately from published content.
  * Improved data privacy with automatic filtering of sensitive information in public views.

* **Tests**
  * Added comprehensive unit tests for shadow data handling and field filtering.

* **Refactor**
  * Consolidated trip data utilities for improved maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/297?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->