### PR TITLE
Harden YNAB token handling

### DIFF
--- a/src/app/__tests__/api/ynab-token-boundary.test.ts
+++ b/src/app/__tests__/api/ynab-token-boundary.test.ts
@@ -1,0 +1,223 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+
+import { GET as costTrackingGET } from '@/app/api/cost-tracking/route';
+import { GET as costTrackingListGET } from '@/app/api/cost-tracking/list/route';
+import { POST as ynabCategoriesPOST } from '@/app/api/ynab/categories/route';
+import {
+  GET as ynabTransactionsGET,
+  POST as ynabTransactionsPOST,
+} from '@/app/api/ynab/transactions/route';
+import { loadUnifiedTripData, listAllTrips } from '@/app/lib/unifiedDataService';
+import { YnabApiClient } from '@/app/lib/ynabApiClient';
+
+const mockGetCategories = jest.fn();
+
+jest.mock('@/app/lib/server-domains', () => ({
+  __esModule: true,
+  isAdminDomain: jest.fn(),
+}));
+
+jest.mock('@/app/lib/unifiedDataService', () => ({
+  __esModule: true,
+  loadUnifiedTripData: jest.fn(),
+  listAllTrips: jest.fn(),
+}));
+
+jest.mock('@/app/lib/ynabPendingSync', () => ({
+  __esModule: true,
+  maybeSyncPendingYnabTransactions: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('@/app/lib/tripBoundaryValidation', () => ({
+  __esModule: true,
+  validateAllTripBoundaries: jest.fn(() => ({ isValid: true, errors: [] })),
+}));
+
+jest.mock('@/app/lib/ynabApiClient', () => ({
+  __esModule: true,
+  YnabApiClient: Object.assign(
+    jest.fn().mockImplementation(() => ({
+      getCategories: mockGetCategories,
+    })),
+    {
+      convertMilliUnitsToCurrency: jest.fn((amount: number) => amount / 1000),
+    }
+  ),
+}));
+
+const { isAdminDomain: mockIsAdminDomain } = jest.requireMock('@/app/lib/server-domains');
+const mockLoadUnifiedTripData = loadUnifiedTripData as jest.MockedFunction<typeof loadUnifiedTripData>;
+const mockListAllTrips = listAllTrips as jest.MockedFunction<typeof listAllTrips>;
+const mockYnabApiClient = YnabApiClient as jest.MockedClass<typeof YnabApiClient>;
+
+const buildTrip = () => ({
+  schemaVersion: 9,
+  id: 'trip-1',
+  title: 'Secret Budget Trip',
+  description: '',
+  startDate: '2026-06-01',
+  endDate: '2026-06-10',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-02T00:00:00.000Z',
+  travelData: {
+    locations: [],
+    routes: [],
+  },
+  costData: {
+    overallBudget: 1000,
+    reservedBudget: 0,
+    currency: 'EUR',
+    countryBudgets: [],
+    expenses: [],
+    ynabConfig: {
+      costTrackerId: 'cost-trip-1',
+      apiKey: 'SECRET-YNAB-TOKEN',
+      selectedBudgetId: 'budget-1',
+      selectedBudgetName: 'Travel Budget',
+      currency: 'EUR',
+    },
+  },
+});
+
+describe('YNAB token boundary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('redacts stored YNAB tokens from cost-tracking GET responses', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+    mockLoadUnifiedTripData.mockResolvedValue(buildTrip());
+
+    const response = await costTrackingGET(
+      new NextRequest('https://admin.example.test/api/cost-tracking?id=trip-1')
+    );
+    const result = await response.json();
+    const serialized = JSON.stringify(result);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(result.ynabConfig).toMatchObject({
+      costTrackerId: 'cost-trip-1',
+      selectedBudgetId: 'budget-1',
+      hasApiKey: true,
+    });
+    expect(result.ynabConfig.apiKey).toBeUndefined();
+    expect(serialized).not.toContain('SECRET-YNAB-TOKEN');
+  });
+
+  it('redacts stored YNAB tokens from cost-tracking list data', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+    mockListAllTrips.mockResolvedValue([
+      {
+        id: 'trip-1',
+        title: 'Secret Budget Trip',
+        description: '',
+        startDate: '2026-06-01',
+        endDate: '2026-06-10',
+        createdAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-02T00:00:00.000Z',
+        hasTravel: true,
+        hasCost: true,
+      },
+    ]);
+    mockLoadUnifiedTripData.mockResolvedValue(buildTrip());
+
+    const response = await costTrackingListGET(
+      new NextRequest('https://admin.example.test/api/cost-tracking/list?includeCostData=1')
+    );
+    const result = await response.json();
+    const serialized = JSON.stringify(result);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(result[0].costData.ynabConfig.hasApiKey).toBe(true);
+    expect(result[0].costData.ynabConfig.apiKey).toBeUndefined();
+    expect(serialized).not.toContain('SECRET-YNAB-TOKEN');
+  });
+
+  it('rejects public YNAB category proxy calls before contacting YNAB', async () => {
+    mockIsAdminDomain.mockResolvedValue(false);
+
+    const response = await ynabCategoriesPOST(
+      new NextRequest('https://public.example.test/api/ynab/categories', {
+        method: 'POST',
+        body: JSON.stringify({ costTrackerId: 'cost-trip-1' }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockYnabApiClient).not.toHaveBeenCalled();
+  });
+
+  it('disables YNAB transaction GET so API keys cannot be placed in URLs', async () => {
+    const response = await ynabTransactionsGET();
+    const result = await response.json();
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(result.error).toContain('Use POST');
+  });
+
+  it('rejects public YNAB transaction proxy calls before contacting YNAB', async () => {
+    mockIsAdminDomain.mockResolvedValue(false);
+
+    const response = await ynabTransactionsPOST(
+      new NextRequest('https://public.example.test/api/ynab/transactions', {
+        method: 'POST',
+        body: JSON.stringify({
+          costTrackerId: 'cost-trip-1',
+          categoryMappings: [{ ynabCategoryId: 'cat-1', mappingType: 'general' }],
+        }),
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockYnabApiClient).not.toHaveBeenCalled();
+  });
+
+  it('loads YNAB categories using the server-stored token for admin callers', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+    mockLoadUnifiedTripData.mockResolvedValue(buildTrip());
+    mockGetCategories.mockResolvedValue({
+      categories: [
+        {
+          id: 'cat-1',
+          name: 'Hotels',
+          category_group_name: 'Travel',
+          hidden: false,
+          balance: 0,
+          budgeted: 1000,
+          activity: -500,
+        },
+      ],
+      serverKnowledge: 42,
+    });
+
+    const response = await ynabCategoriesPOST(
+      new NextRequest('https://admin.example.test/api/ynab/categories', {
+        method: 'POST',
+        body: JSON.stringify({ costTrackerId: 'cost-trip-1' }),
+      })
+    );
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe('no-store');
+    expect(mockYnabApiClient).toHaveBeenCalledWith('SECRET-YNAB-TOKEN');
+    expect(result).toMatchObject({
+      success: true,
+      serverKnowledge: 42,
+      categories: [
+        {
+          id: 'cat-1',
+          name: 'Hotels',
+          category_group_name: 'Travel',
+        },
+      ],
+    });
+  });
+});

--- a/src/app/admin/components/YnabImportForm.tsx
+++ b/src/app/admin/components/YnabImportForm.tsx
@@ -55,6 +55,7 @@ interface TransactionSelection {
  * @returns A React element that displays the YNAB import modal and its interactive steps
  */
 export default function YnabImportForm({ isOpen, costData, onImportComplete, onClose }: YnabImportFormProps) {
+  const hasYnabApiKey = Boolean(costData.ynabConfig?.apiKey || costData.ynabConfig?.hasApiKey);
   const [currentStep, setCurrentStep] = useState(0); // Start with method selection
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -397,7 +398,7 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
 
   // Load categories from YNAB API for mapping
   const handleLoadCategoriesFromApi = async () => {
-    if (!costData.ynabConfig?.apiKey || !costData.ynabConfig?.selectedBudgetId) {
+    if (!hasYnabApiKey || !costData.ynabConfig?.selectedBudgetId) {
       setError('YNAB API configuration not found. Please setup YNAB API first.');
       return;
     }
@@ -407,19 +408,15 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
 
     try {
       const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000';
-      const params = new URLSearchParams({
-        apiKey: costData.ynabConfig.apiKey,
-        budgetId: costData.ynabConfig.selectedBudgetId,
-        ...(costData.ynabConfig.categoryServerKnowledge && {
-          serverKnowledge: costData.ynabConfig.categoryServerKnowledge.toString()
-        })
-      });
-
-      const response = await fetch(`${baseUrl}/api/ynab/categories?${params}`, {
-        method: 'GET',
+      const response = await fetch(`${baseUrl}/api/ynab/categories`, {
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-        }
+        },
+        body: JSON.stringify({
+          costTrackerId: costData.id,
+          serverKnowledge: costData.ynabConfig.categoryServerKnowledge
+        })
       });
 
       if (!response.ok) {
@@ -528,7 +525,7 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
 
   // Load transactions from API directly
   const loadTransactionsFromApi = async (mappingOverride?: YnabCategoryMapping[]) => {
-    if (!costData.ynabConfig?.apiKey || !costData.ynabConfig?.selectedBudgetId) {
+    if (!hasYnabApiKey || !costData.ynabConfig?.selectedBudgetId) {
       setError('YNAB API configuration not found. Please setup YNAB API first.');
       return;
     }
@@ -545,8 +542,7 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          apiKey: costData.ynabConfig.apiKey,
-          budgetId: costData.ynabConfig.selectedBudgetId,
+          costTrackerId: costData.id,
           categoryMappings: (mappingOverride ?? categoryMappings).map(mapping => ({
             ynabCategoryId: mapping.ynabCategoryId,
             mappingType: mapping.mappingType,
@@ -960,15 +956,15 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
 	                  className={`border-2 rounded-lg p-6 transition-all duration-200 ${
 	                    importMethod === 'api' 
 	                      ? 'border-purple-500 bg-purple-50 dark:bg-purple-950' 
-	                      : costData.ynabConfig?.apiKey
+	                      : hasYnabApiKey
 	                        ? 'border-gray-300 dark:border-gray-600 hover:border-purple-300 dark:hover:border-purple-700'
 	                        : 'border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 cursor-not-allowed'
 	                  }`}
 	                >
 	                  <label
 	                    htmlFor="import-method-api"
-	                    aria-disabled={!costData.ynabConfig?.apiKey}
-	                    className={`block ${costData.ynabConfig?.apiKey ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+	                    aria-disabled={!hasYnabApiKey}
+	                    className={`block ${hasYnabApiKey ? 'cursor-pointer' : 'cursor-not-allowed'}`}
 	                  >
 	                    <div className="flex items-center mb-4">
 	                      <input
@@ -978,21 +974,21 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
 	                        value="api"
 	                        checked={importMethod === 'api'}
 	                        onChange={() => setImportMethod('api')}
-	                        disabled={!costData.ynabConfig?.apiKey}
+	                        disabled={!hasYnabApiKey}
 	                        className="mr-3"
 	                      />
 	                      <h3 className={`text-lg font-semibold ${
-	                        costData.ynabConfig?.apiKey 
+	                        hasYnabApiKey 
 	                          ? 'text-gray-800 dark:text-gray-100' 
 	                          : 'text-gray-400 dark:text-gray-500'
 	                      }`}>
 	                        Load from YNAB API
 	                      </h3>
 	                    </div>
-	                    {costData.ynabConfig?.apiKey ? (
+	                    {hasYnabApiKey ? (
 	                      <>
 	                        <p className="text-sm text-gray-600 dark:text-gray-300 mb-3">
-	                          Load transactions directly from your connected YNAB budget: <strong>{costData.ynabConfig.selectedBudgetName}</strong>
+	                          Load transactions directly from your connected YNAB budget: <strong>{costData.ynabConfig?.selectedBudgetName}</strong>
 	                        </p>
 	                        <div className="text-sm text-gray-500 dark:text-gray-400">
 	                          ✓ Real-time data sync<br />
@@ -1012,7 +1008,7 @@ export default function YnabImportForm({ isOpen, costData, onImportComplete, onC
 	                      </>
 	                    )}
 	                  </label>
-	                  {costData.ynabConfig?.apiKey && importMethod === 'api' && (
+	                  {hasYnabApiKey && importMethod === 'api' && (
 	                    <div className="mt-4 pt-3 border-t border-purple-200 dark:border-purple-700">
 	                      <label htmlFor="sync-mode-select" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
 	                        Sync Mode

--- a/src/app/admin/components/YnabMappingManager.tsx
+++ b/src/app/admin/components/YnabMappingManager.tsx
@@ -76,6 +76,7 @@ interface YnabMappingManagerProps {
 }
 
 export default function YnabMappingManager({ isOpen, costData, onSave, onClose }: YnabMappingManagerProps) {
+  const hasYnabApiKey = Boolean(costData.ynabConfig?.apiKey || costData.ynabConfig?.hasApiKey);
   const [mappings, setMappings] = useState<YnabCategoryMapping[]>([]);
   const [extractedCategories, setExtractedCategories] = useState<string[]>([]);
   const [isUploading, setIsUploading] = useState(false);
@@ -160,7 +161,7 @@ export default function YnabMappingManager({ isOpen, costData, onSave, onClose }
 
   // Load categories from YNAB API
   const handleLoadCategoriesFromApi = async () => {
-    if (!costData.ynabConfig?.apiKey || !costData.ynabConfig?.selectedBudgetId) {
+    if (!hasYnabApiKey || !costData.ynabConfig?.selectedBudgetId) {
       alert('YNAB API configuration not found. Please setup YNAB API first.');
       return;
     }
@@ -170,19 +171,15 @@ export default function YnabMappingManager({ isOpen, costData, onSave, onClose }
 
     try {
       const baseUrl = typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000';
-      const params = new URLSearchParams({
-        apiKey: costData.ynabConfig.apiKey,
-        budgetId: costData.ynabConfig.selectedBudgetId,
-        ...(costData.ynabConfig.categoryServerKnowledge && {
-          serverKnowledge: costData.ynabConfig.categoryServerKnowledge.toString()
-        })
-      });
-      
-      const response = await fetch(`${baseUrl}/api/ynab/categories?${params}`, {
-        method: 'GET',
+      const response = await fetch(`${baseUrl}/api/ynab/categories`, {
+        method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-        }
+        },
+        body: JSON.stringify({
+          costTrackerId: costData.id,
+          serverKnowledge: costData.ynabConfig.categoryServerKnowledge
+        })
       });
 
       if (!response.ok) {
@@ -407,11 +404,11 @@ export default function YnabMappingManager({ isOpen, costData, onSave, onClose }
       </div>
 
       {/* YNAB API Category Loading */}
-      {costData.ynabConfig?.apiKey && (
+      {hasYnabApiKey && (
         <div className="bg-purple-50 dark:bg-purple-950 border border-purple-200 dark:border-purple-700 rounded-lg p-4 mb-6">
           <h3 className="text-lg font-semibold mb-3 text-purple-800 dark:text-purple-200">Load Categories from YNAB API</h3>
           <p className="text-sm text-purple-700 dark:text-purple-300 mb-4">
-            Load categories directly from your connected YNAB budget: <strong>{costData.ynabConfig.selectedBudgetName}</strong>
+            Load categories directly from your connected YNAB budget: <strong>{costData.ynabConfig?.selectedBudgetName}</strong>
           </p>
           
           <div className="flex items-center gap-4 mb-3">
@@ -464,7 +461,7 @@ export default function YnabMappingManager({ isOpen, costData, onSave, onClose }
         </div>
       )}
 
-      {!costData.ynabConfig?.apiKey && (
+      {!hasYnabApiKey && (
         <div className="bg-yellow-50 dark:bg-yellow-950 border border-yellow-200 dark:border-yellow-700 rounded-lg p-4 mb-6">
           <h3 className="text-lg font-semibold mb-2 text-yellow-800 dark:text-yellow-200">YNAB API Not Configured</h3>
           <p className="text-sm text-yellow-700 dark:text-yellow-300">

--- a/src/app/api/cost-tracking/list/route.ts
+++ b/src/app/api/cost-tracking/list/route.ts
@@ -3,6 +3,7 @@ import { listAllTrips, loadUnifiedTripData } from '@/app/lib/unifiedDataService'
 import { CostTrackingData, Expense } from '@/app/types';
 import { isAdminDomain } from '@/app/lib/server-domains';
 import { validateAllTripBoundaries } from '@/app/lib/tripBoundaryValidation';
+import { PRIVATE_JSON_HEADERS, redactYnabConfig } from '@/app/lib/ynabConfigSecurity';
 
 function buildLegacyCostData(tripId: string, unifiedData: Awaited<ReturnType<typeof loadUnifiedTripData>>): CostTrackingData | null {
   if (!unifiedData?.costData) {
@@ -22,7 +23,7 @@ function buildLegacyCostData(tripId: string, unifiedData: Awaited<ReturnType<typ
     countryBudgets: unifiedData.costData.countryBudgets,
     expenses: unifiedData.costData.expenses,
     ynabImportData: unifiedData.costData.ynabImportData,
-    ynabConfig: unifiedData.costData.ynabConfig,
+    ynabConfig: redactYnabConfig(unifiedData.costData.ynabConfig),
     createdAt: unifiedData.createdAt,
     updatedAt: unifiedData.updatedAt
   };
@@ -106,7 +107,7 @@ export async function GET(request: NextRequest) {
     // Filter out null entries
     const validCostEntries = costEntries.filter(entry => entry !== null);
 
-    return NextResponse.json(validCostEntries);
+    return NextResponse.json(validCostEntries, { headers: PRIVATE_JSON_HEADERS });
   } catch (error) {
     console.error('Error listing cost tracking data:', error);
     return NextResponse.json(

--- a/src/app/api/cost-tracking/route.ts
+++ b/src/app/api/cost-tracking/route.ts
@@ -5,6 +5,7 @@ import { isAdminDomain } from '@/app/lib/server-domains';
 import { validateAllTripBoundaries } from '@/app/lib/tripBoundaryValidation';
 import { dateReviver } from '@/app/lib/jsonDateReviver';
 import { applyCostDataDelta, isCostDataDelta, isCostDataDeltaEmpty } from '@/app/lib/costDataDelta';
+import { PRIVATE_JSON_HEADERS, redactYnabConfig } from '@/app/lib/ynabConfigSecurity';
 import type { CostTrackingData } from '@/app/types';
 import { parseDateAsLocalDay } from '@/app/lib/localDateUtils';
 
@@ -40,8 +41,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ 
       success: true, 
       id,
-      data: legacyData
-    });
+      data: {
+        ...legacyData,
+        ynabConfig: redactYnabConfig(legacyData.ynabConfig)
+      }
+    }, { headers: PRIVATE_JSON_HEADERS });
   } catch (error) {
     console.error('Error saving cost tracking data:', error);
     return NextResponse.json(
@@ -108,14 +112,14 @@ export async function GET(request: NextRequest) {
       countryBudgets: costDataSource.costData.countryBudgets,
       expenses: costDataSource.costData.expenses, // These are already trip-scoped by design
       ynabImportData: costDataSource.costData.ynabImportData,
-      ynabConfig: costDataSource.costData.ynabConfig, // Include YNAB API configuration
+      ynabConfig: redactYnabConfig(costDataSource.costData.ynabConfig),
       createdAt: costDataSource.createdAt,
       updatedAt: costDataSource.updatedAt,
       // Add validation status for monitoring
       hasValidationWarnings: !validation.isValid
     };
     
-    return NextResponse.json(costData);
+    return NextResponse.json(costData, { headers: PRIVATE_JSON_HEADERS });
   } catch (error) {
     console.error('Error loading cost tracking data:', error);
     return NextResponse.json(
@@ -169,8 +173,11 @@ export async function PUT(request: NextRequest) {
     return NextResponse.json({ 
       success: true, 
       id: cleanId,
-      data: legacyData
-    });
+      data: {
+        ...legacyData,
+        ynabConfig: redactYnabConfig(legacyData.ynabConfig)
+      }
+    }, { headers: PRIVATE_JSON_HEADERS });
   } catch (error) {
     console.error('Error updating cost tracking data:', error);
     return NextResponse.json(
@@ -273,7 +280,7 @@ export async function PATCH(request: NextRequest) {
       success: true,
       message: 'Delta applied successfully',
       id: cleanId
-    });
+    }, { headers: PRIVATE_JSON_HEADERS });
   } catch (error) {
     console.error('Error patching cost tracking data:', error);
     return NextResponse.json(
@@ -309,7 +316,7 @@ export async function DELETE(request: NextRequest) {
     return NextResponse.json({
       success: true,
       message: `Cost tracking data for "${trip.title}" has been deleted and backed up`
-    });
+    }, { headers: PRIVATE_JSON_HEADERS });
   } catch (error) {
     console.error('Error deleting cost tracking data:', error);
     return NextResponse.json({ error: 'Failed to delete cost tracking data' }, { status: 500 });

--- a/src/app/api/ynab/categories/route.ts
+++ b/src/app/api/ynab/categories/route.ts
@@ -1,35 +1,32 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { YnabApiClient } from '@/app/lib/ynabApiClient';
 import { YnabApiError } from '@/app/types';
+import { PRIVATE_JSON_HEADERS } from '@/app/lib/ynabConfigSecurity';
+import { requireAdminYnabConfig } from '@/app/lib/ynabServerConfig';
 
-export async function GET(request: NextRequest) {
+export async function GET() {
+  return NextResponse.json(
+    { error: 'Use POST for YNAB category sync' },
+    { status: 405, headers: PRIVATE_JSON_HEADERS }
+  );
+}
+
+export async function POST(request: NextRequest) {
   try {
-    const { searchParams } = new URL(request.url);
-    const apiKey = searchParams.get('apiKey');
-    const budgetId = searchParams.get('budgetId');
-    const serverKnowledge = searchParams.get('serverKnowledge');
-
-    if (!apiKey || typeof apiKey !== 'string') {
-      return NextResponse.json(
-        { error: 'API key is required' },
-        { status: 400 }
-      );
-    }
-
-    if (!budgetId || typeof budgetId !== 'string') {
-      return NextResponse.json(
-        { error: 'Budget ID is required' },
-        { status: 400 }
-      );
+    const body = await request.json();
+    const { costTrackerId, serverKnowledge } = body;
+    const configResult = await requireAdminYnabConfig(costTrackerId);
+    if (configResult.response) {
+      return configResult.response;
     }
 
     // Create YNAB API client
-    const client = new YnabApiClient(apiKey);
+    const client = new YnabApiClient(configResult.config.apiKey!);
 
     try {
       // Get categories with optional delta sync
       const result = await client.getCategories(
-        budgetId,
+        configResult.config.selectedBudgetId,
         serverKnowledge ? parseInt(serverKnowledge) : undefined
       );
 
@@ -47,12 +44,7 @@ export async function GET(request: NextRequest) {
           })),
           serverKnowledge: result.serverKnowledge
         },
-        {
-          headers: {
-            // YNAB data should not be cached at CDN because it’s user-specific and sensitive
-            'Cache-Control': 'no-store'
-          }
-        }
+        { headers: PRIVATE_JSON_HEADERS }
       );
 
     } catch (ynabError) {

--- a/src/app/api/ynab/setup/route.ts
+++ b/src/app/api/ynab/setup/route.ts
@@ -1,9 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { YnabApiClient } from '@/app/lib/ynabApiClient';
 import { YnabBudget, YnabApiError } from '@/app/types';
+import { isAdminDomain } from '@/app/lib/server-domains';
+import { PRIVATE_JSON_HEADERS } from '@/app/lib/ynabConfigSecurity';
 
 export async function POST(request: NextRequest) {
   try {
+    const isAdmin = await isAdminDomain();
+    if (!isAdmin) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 403, headers: PRIVATE_JSON_HEADERS }
+      );
+    }
+
     const body = await request.json();
     const { apiKey, costTrackerId } = body;
 
@@ -40,11 +50,7 @@ export async function POST(request: NextRequest) {
             currency_format: budget.currency_format
           }))
         },
-        {
-          headers: {
-            'Cache-Control': 'no-store'
-          }
-        }
+        { headers: PRIVATE_JSON_HEADERS }
       );
 
     } catch (ynabError) {

--- a/src/app/api/ynab/transactions/route.ts
+++ b/src/app/api/ynab/transactions/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { YnabApiClient, ynabUtils } from '@/app/lib/ynabApiClient';
 import { YnabApiError, ProcessedYnabTransaction, CategoryMapping } from '@/app/types';
+import { PRIVATE_JSON_HEADERS } from '@/app/lib/ynabConfigSecurity';
+import { requireAdminYnabConfig } from '@/app/lib/ynabServerConfig';
 
 /**
  * Retrieve YNAB transactions filtered by mapped category IDs and return them in ProcessedYnabTransaction format.
@@ -17,172 +19,17 @@ import { YnabApiError, ProcessedYnabTransaction, CategoryMapping } from '@/app/t
  *
  * On error the JSON body includes `error` (message) and `code` (error identifier).
  */
-export async function GET(request: NextRequest) {
-  try {
-    const { searchParams } = new URL(request.url);
-    const apiKey = searchParams.get('apiKey');
-    const budgetId = searchParams.get('budgetId');
-    const mappedCategoryIds = searchParams.get('categoryIds');
-    const sinceDate = searchParams.get('sinceDate');
-    const serverKnowledge = searchParams.get('serverKnowledge');
-
-    if (!apiKey || typeof apiKey !== 'string') {
-      return NextResponse.json(
-        { error: 'API key is required' },
-        { status: 400 }
-      );
-    }
-
-    if (!budgetId || typeof budgetId !== 'string') {
-      return NextResponse.json(
-        { error: 'Budget ID is required' },
-        { status: 400 }
-      );
-    }
-
-    if (!mappedCategoryIds) {
-      return NextResponse.json(
-        { error: 'Category IDs are required' },
-        { status: 400 }
-      );
-    }
-
-    // Parse category IDs from comma-separated string
-    const categoryIds = mappedCategoryIds.split(',').filter(id => id.trim());
-
-    if (categoryIds.length === 0) {
-      return NextResponse.json({
-        success: true,
-        transactions: [],
-        serverKnowledge: 0,
-        message: 'No categories mapped for transaction retrieval'
-      });
-    }
-
-    // Create YNAB API client
-    const client = new YnabApiClient(apiKey);
-
-    try {
-      // Get transactions filtered by mapped category IDs
-      const result = await client.getTransactions(
-        budgetId,
-        categoryIds,
-        sinceDate || undefined,
-        serverKnowledge ? parseInt(serverKnowledge) : undefined
-      );
-
-      const expandedTransactions = ynabUtils.flattenTransactions(result.transactions);
-
-      // Convert YNAB transactions to ProcessedYnabTransaction format
-      const processedTransactions: ProcessedYnabTransaction[] = expandedTransactions.map((txn, index) => {
-        const amount = Math.abs(ynabUtils.milliunitsToAmount(txn.amount));
-        const isOutflow = txn.amount < 0;
-        const hash = ynabUtils.generateTransactionHash(txn);
-
-        return {
-          originalTransaction: {
-            Account: txn.account_name || '',
-            Flag: txn.flag_name || '',
-            Date: txn.date,
-            Payee: txn.payee_name || '',
-            'Category Group/Category': txn.category_name || '',
-            'Category Group': '', // Not directly available in API response
-            Category: txn.category_name || '',
-            Memo: txn.memo || '',
-            Outflow: isOutflow ? amount.toString() : '',
-            Inflow: !isOutflow ? amount.toString() : '',
-            Cleared: txn.cleared
-          },
-          amount: isOutflow ? amount : -amount, // Expenses are positive, income is negative
-          date: txn.date,
-          description: txn.payee_name || 'Unknown Payee',
-          memo: txn.memo || '',
-          mappedCountry: '', // Will be determined by category mapping
-          isGeneralExpense: false, // Will be determined by category mapping
-          hash,
-          instanceId: txn.id || `${hash}-${index}`,
-          sourceIndex: index,
-          expenseType: 'actual',
-          ynabTransactionId: txn.id,
-          importId: txn.import_id
-        };
-      });
-
-      return NextResponse.json(
-        {
-          success: true,
-          transactions: processedTransactions,
-          serverKnowledge: result.serverKnowledge,
-          totalCount: processedTransactions.length
-        },
-        {
-          headers: {
-            // User-specific financial data must not be cached
-            'Cache-Control': 'no-store'
-          }
-        }
-      );
-
-    } catch (ynabError) {
-      const error = ynabError as YnabApiError;
-      
-      // Handle specific YNAB API errors
-      if (error.id === '401') {
-        return NextResponse.json(
-          { 
-            error: 'Invalid API key. Please check your YNAB Personal Access Token.',
-            code: 'INVALID_API_KEY'
-          },
-          { status: 401 }
-        );
-      }
-
-      if (error.id === '404') {
-        return NextResponse.json(
-          { 
-            error: 'Budget not found. Please check the budget ID.',
-            code: 'BUDGET_NOT_FOUND'
-          },
-          { status: 404 }
-        );
-      }
-
-      if (error.id === '429') {
-        return NextResponse.json(
-          { 
-            error: 'Rate limit exceeded. Please wait a moment and try again.',
-            code: 'RATE_LIMIT'
-          },
-          { status: 429 }
-        );
-      }
-
-      // Generic YNAB API error
-      return NextResponse.json(
-        { 
-          error: `YNAB API Error: ${error.detail}`,
-          code: 'YNAB_API_ERROR'
-        },
-        { status: 500 }
-      );
-    }
-
-  } catch (error) {
-    console.error('YNAB transactions error:', error);
-    return NextResponse.json(
-      { 
-        error: 'Failed to fetch YNAB transactions',
-        code: 'TRANSACTIONS_ERROR'
-      },
-      { status: 500 }
-    );
-  }
+export async function GET() {
+  return NextResponse.json(
+    { error: 'Use POST for YNAB transaction sync' },
+    { status: 405, headers: PRIVATE_JSON_HEADERS }
+  );
 }
 
 /**
  * Handle POST requests to fetch YNAB transactions for mapped categories and return them in a processed import-ready format.
  *
- * @param request - Incoming NextRequest whose JSON body must include `apiKey` (string), `budgetId` (string), and `categoryMappings` (array). Optional body fields: `sinceDate` and `serverKnowledge`.
+ * @param request - Incoming NextRequest whose JSON body must include `costTrackerId` (string) and `categoryMappings` (array). Optional body fields: `sinceDate` and `serverKnowledge`.
  * @returns On success, a JSON object containing:
  * - `success`: `true`
  * - `transactions`: an array of processed transactions where each item includes `originalTransaction`, `amount`, `date`, `description`, `memo`, `mappedCountry`, `isGeneralExpense`, `hash`, `instanceId`, `sourceIndex`, `expenseType`, `ynabTransactionId`, and `importId`.
@@ -195,25 +42,15 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     const { 
-      apiKey, 
-      budgetId, 
+      costTrackerId,
       categoryMappings, 
       sinceDate,
       serverKnowledge 
     } = body;
 
-    if (!apiKey || typeof apiKey !== 'string') {
-      return NextResponse.json(
-        { error: 'API key is required' },
-        { status: 400 }
-      );
-    }
-
-    if (!budgetId || typeof budgetId !== 'string') {
-      return NextResponse.json(
-        { error: 'Budget ID is required' },
-        { status: 400 }
-      );
+    const configResult = await requireAdminYnabConfig(costTrackerId);
+    if (configResult.response) {
+      return configResult.response;
     }
 
     if (!categoryMappings || !Array.isArray(categoryMappings)) {
@@ -236,16 +73,16 @@ export async function POST(request: NextRequest) {
         transactions: [],
         serverKnowledge: serverKnowledge || 0,
         message: 'No categories mapped for transaction retrieval. Please use "YNAB Category Mappings" to map categories first, then save the mappings before importing transactions.'
-      });
+      }, { headers: PRIVATE_JSON_HEADERS });
     }
 
     // Create YNAB API client
-    const client = new YnabApiClient(apiKey);
+    const client = new YnabApiClient(configResult.config.apiKey!);
 
     try {
       // Get transactions using efficient category-specific API calls with delta sync
       const result = await client.getTransactionsByCategories(
-        budgetId,
+        configResult.config.selectedBudgetId,
         mappedCategoryIds,
         sinceDate || undefined,
         serverKnowledge || undefined
@@ -307,11 +144,7 @@ export async function POST(request: NextRequest) {
           serverKnowledge: result.serverKnowledge,
           totalCount: processedTransactions.length
         },
-        {
-          headers: {
-            'Cache-Control': 'no-store'
-          }
-        }
+        { headers: PRIVATE_JSON_HEADERS }
       );
 
     } catch (ynabError) {

--- a/src/app/lib/unifiedDataService.ts
+++ b/src/app/lib/unifiedDataService.ts
@@ -20,6 +20,7 @@ import { getDataDir } from './dataDirectory';
 import { dateReviver } from './jsonDateReviver';
 import { buildTripUpdates } from './tripUpdates';
 import { ConflictError, NotFoundError, ValidationError } from './errors';
+import { mergeYnabConfigForStorage } from './ynabConfigSecurity';
 
 const getDataDirPath = () => getDataDir();
 const getBackupDirPath = () => join(getDataDirPath(), 'backups');
@@ -822,7 +823,10 @@ export async function updateCostData(tripId: string, costUpdates: Record<string,
       expenses: (costUpdates.expenses as Expense[]) || baseData.costData?.expenses || [],
       ...(resolvedCustomCategories ? { customCategories: resolvedCustomCategories } : {}),
       ynabImportData: (costUpdates.ynabImportData as YnabImportData) || baseData.costData?.ynabImportData,
-      ynabConfig: (costUpdates.ynabConfig as YnabConfig) || baseData.costData?.ynabConfig // YNAB API configuration
+      ynabConfig: mergeYnabConfigForStorage(
+        costUpdates.ynabConfig as YnabConfig | undefined,
+        baseData.costData?.ynabConfig
+      )
     }
   };
 

--- a/src/app/lib/ynabConfigSecurity.ts
+++ b/src/app/lib/ynabConfigSecurity.ts
@@ -1,0 +1,36 @@
+import type { YnabConfig } from '@/app/types';
+
+export const PRIVATE_JSON_HEADERS = {
+  'Cache-Control': 'no-store'
+};
+
+export function redactYnabConfig(config?: YnabConfig): YnabConfig | undefined {
+  if (!config) {
+    return undefined;
+  }
+
+  const safeConfig = { ...config };
+  delete safeConfig.apiKey;
+  return {
+    ...safeConfig,
+    hasApiKey: Boolean(config.apiKey || config.hasApiKey)
+  };
+}
+
+export function mergeYnabConfigForStorage(
+  incoming?: YnabConfig,
+  existing?: YnabConfig
+): YnabConfig | undefined {
+  if (!incoming) {
+    return existing;
+  }
+
+  const merged: YnabConfig = {
+    ...existing,
+    ...incoming,
+    apiKey: incoming.apiKey || existing?.apiKey
+  };
+
+  delete merged.hasApiKey;
+  return merged;
+}

--- a/src/app/lib/ynabPendingSync.ts
+++ b/src/app/lib/ynabPendingSync.ts
@@ -87,13 +87,18 @@ export async function maybeSyncPendingYnabTransactions(
 
   const sinceDate = buildSinceDate(costData.ynabConfig);
   const serverKnowledge = buildServerKnowledge(costData.ynabConfig);
+  const { apiKey, selectedBudgetId } = costData.ynabConfig;
 
-  const client = new YnabApiClient(costData.ynabConfig.apiKey);
+  if (!apiKey || !selectedBudgetId) {
+    return null;
+  }
+
+  const client = new YnabApiClient(apiKey);
   let transactionResult: { transactions: YnabApiTransaction[]; serverKnowledge: number };
 
   try {
     transactionResult = await client.getTransactionsByCategories(
-      costData.ynabConfig.selectedBudgetId,
+      selectedBudgetId,
       mappedCategories,
       sinceDate,
       serverKnowledge

--- a/src/app/lib/ynabServerConfig.ts
+++ b/src/app/lib/ynabServerConfig.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { isAdminDomain } from '@/app/lib/server-domains';
+import { loadUnifiedTripData } from '@/app/lib/unifiedDataService';
+import { PRIVATE_JSON_HEADERS } from '@/app/lib/ynabConfigSecurity';
+import type { YnabConfig } from '@/app/types';
+
+type StoredYnabConfigResult =
+  | { config: YnabConfig; response?: never }
+  | { config?: never; response: NextResponse };
+
+export async function requireAdminYnabConfig(costTrackerId: unknown): Promise<StoredYnabConfigResult> {
+  const isAdmin = await isAdminDomain();
+  if (!isAdmin) {
+    return {
+      response: NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 403, headers: PRIVATE_JSON_HEADERS }
+      )
+    };
+  }
+
+  if (!costTrackerId || typeof costTrackerId !== 'string') {
+    return {
+      response: NextResponse.json(
+        { error: 'Cost tracker ID is required' },
+        { status: 400, headers: PRIVATE_JSON_HEADERS }
+      )
+    };
+  }
+
+  const cleanId = costTrackerId.replace(/^(cost-)+/, '');
+  const unifiedData = await loadUnifiedTripData(cleanId);
+  const config = unifiedData?.costData?.ynabConfig;
+  if (!config?.apiKey || !config.selectedBudgetId) {
+    return {
+      response: NextResponse.json(
+        { error: 'YNAB API configuration not found' },
+        { status: 404, headers: PRIVATE_JSON_HEADERS }
+      )
+    };
+  }
+
+  return { config };
+}

--- a/src/app/types/index.ts
+++ b/src/app/types/index.ts
@@ -424,7 +424,8 @@ export interface CategoryMapping {
 // YNAB API configuration - scoped to specific cost tracker
 export interface YnabConfig {
   costTrackerId: string; // CRITICAL: Scope to specific cost tracker for data isolation
-  apiKey: string;
+  apiKey?: string;
+  hasApiKey?: boolean;
   selectedBudgetId: string;
   selectedBudgetName: string;
   currency: string;


### PR DESCRIPTION
## Summary
- redact stored YNAB API tokens from cost-tracking detail and list responses while preserving a hasApiKey indicator for the admin UI
- preserve the stored YNAB token when later redacted admin payloads update cost data
- require admin-domain access for YNAB setup/proxy routes and move category/transaction sync to server-stored tokens keyed by costTrackerId
- disable YNAB transaction/category GET token proxy paths so API keys are not sent in URLs

## Security findings
- 5fd67823706481919428044faddd01f7 YNAB API token exposed by cost-tracking GET
- 34890cfeebd08191806c58d659f83a94 Unauthenticated YNAB proxy enables token leakage and DoS

## Verification
- bun run test:unit -- src/app/__tests__/api/ynab-token-boundary.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bunx eslint src/app/api/cost-tracking/route.ts src/app/api/cost-tracking/list/route.ts src/app/api/ynab/setup/route.ts src/app/api/ynab/categories/route.ts src/app/api/ynab/transactions/route.ts src/app/lib/ynabConfigSecurity.ts src/app/lib/ynabServerConfig.ts src/app/lib/ynabPendingSync.ts src/app/lib/unifiedDataService.ts src/app/admin/components/YnabImportForm.tsx src/app/admin/components/YnabMappingManager.tsx src/app/types/index.ts src/app/__tests__/api/ynab-token-boundary.test.ts
- bun run build