### PR TITLE
Harden public map redaction

### DIFF
--- a/src/app/__tests__/api/travel-data-list-privacy.test.ts
+++ b/src/app/__tests__/api/travel-data-list-privacy.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment node
+ */
+
+import { GET } from '@/app/api/travel-data/list/route';
+import { listAllTrips } from '@/app/lib/unifiedDataService';
+
+jest.mock('@/app/lib/unifiedDataService', () => ({
+  __esModule: true,
+  listAllTrips: jest.fn(),
+}));
+
+const mockListAllTrips = listAllTrips as jest.MockedFunction<typeof listAllTrips>;
+
+describe('travel-data list privacy', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('counts only public accommodations in unauthenticated trip listings', async () => {
+    mockListAllTrips.mockResolvedValue([
+      {
+        id: 'trip-1',
+        title: 'Listed Trip',
+        startDate: '2026-06-01',
+        endDate: '2026-06-10',
+        createdAt: '2026-05-01T00:00:00.000Z',
+        hasTravel: true,
+        hasCost: false,
+        isUnified: true,
+        locationCount: 2,
+        accommodationCount: 2,
+        publicAccommodationCount: 1,
+        routeCount: 1,
+      },
+    ]);
+
+    const response = await GET();
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'trip-1',
+        accommodationCount: 1,
+      }),
+    ]);
+    expect(JSON.stringify(result)).not.toContain('Private Hotel');
+    expect(JSON.stringify(result)).not.toContain('booking code');
+  });
+});

--- a/src/app/__tests__/lib/mapRouteTransform.test.ts
+++ b/src/app/__tests__/lib/mapRouteTransform.test.ts
@@ -1,0 +1,52 @@
+import { normalizeMapTravelData, toMapRouteSegment } from '@/app/lib/mapRouteTransform';
+
+describe('map route transform privacy defaults', () => {
+  const routeWithPrivateNotes = {
+    id: 'route-1',
+    from: 'Paris',
+    to: 'Brussels',
+    type: 'train',
+    fromCoordinates: [48.8566, 2.3522] as [number, number],
+    toCoordinates: [50.8503, 4.3517] as [number, number],
+    departureTime: '2026-06-03T08:00:00.000Z',
+    privateNotes: 'SECRET PLATFORM 9',
+    subRoutes: [
+      {
+        id: 'segment-1',
+        from: 'Paris',
+        to: 'Lille',
+        type: 'train',
+        privateNotes: 'SECRET SUBROUTE PNR',
+      },
+    ],
+  };
+
+  it('does not map private route notes into public map notes by default', () => {
+    const result = toMapRouteSegment(routeWithPrivateNotes);
+    const serialized = JSON.stringify(result);
+
+    expect(result.notes).toBe('');
+    expect(result.subRoutes?.[0]?.notes).toBe('');
+    expect(serialized).not.toContain('SECRET PLATFORM 9');
+    expect(serialized).not.toContain('SECRET SUBROUTE PNR');
+  });
+
+  it('only includes private route notes when admin map transforms opt in', () => {
+    const result = normalizeMapTravelData(
+      {
+        id: 'trip-1',
+        title: 'Admin Trip',
+        description: '',
+        startDate: '2026-06-01',
+        endDate: '2026-06-10',
+        createdAt: '2026-05-01T00:00:00.000Z',
+        locations: [],
+        routes: [routeWithPrivateNotes],
+      },
+      { includePrivateNotes: true }
+    );
+
+    expect(result.routes[0].notes).toBe('SECRET PLATFORM 9');
+    expect(result.routes[0].subRoutes?.[0]?.notes).toBe('SECRET SUBROUTE PNR');
+  });
+});

--- a/src/app/__tests__/lib/unifiedDataService-list-privacy.test.ts
+++ b/src/app/__tests__/lib/unifiedDataService-list-privacy.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('unifiedDataService.listAllTrips privacy summaries', () => {
+  let testDataDir: string;
+
+  beforeEach(() => {
+    testDataDir = mkdtempSync(join(tmpdir(), 'travel-tracker-list-privacy-'));
+    process.env.TEST_DATA_DIR = testDataDir;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.TEST_DATA_DIR;
+    jest.resetModules();
+    rmSync(testDataDir, { recursive: true, force: true });
+  });
+
+  it('calculates public accommodation counts during the trip scan', async () => {
+    const { saveUnifiedTripData, listAllTrips } = await import('../../lib/unifiedDataService');
+    const { CURRENT_SCHEMA_VERSION } = await import('../../lib/dataMigration');
+
+    await saveUnifiedTripData({
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+      id: 'tripListPrivacy',
+      title: 'Listed Trip',
+      description: '',
+      startDate: '2026-06-01',
+      endDate: '2026-06-10',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-02T00:00:00.000Z',
+      travelData: {
+        locations: [],
+        routes: [],
+      },
+      accommodations: [
+        {
+          id: 'private-acc',
+          name: 'Private Hotel',
+          locationId: 'loc-1',
+          accommodationData: 'booking code',
+          isAccommodationPublic: false,
+          createdAt: '2026-05-01T00:00:00.000Z',
+        },
+        {
+          id: 'public-acc',
+          name: 'Public Campsite',
+          locationId: 'loc-2',
+          isAccommodationPublic: true,
+          createdAt: '2026-05-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const [summary] = await listAllTrips();
+
+    expect(summary).toEqual(expect.objectContaining({
+      id: 'tripListPrivacy',
+      accommodationCount: 2,
+      publicAccommodationCount: 1,
+    }));
+    expect(JSON.stringify(summary)).not.toContain('Private Hotel');
+    expect(JSON.stringify(summary)).not.toContain('booking code');
+  });
+});

--- a/src/app/api/travel-data/list/route.ts
+++ b/src/app/api/travel-data/list/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
         endDate: trip.endDate,
         createdAt: trip.createdAt,
         locationCount: trip.locationCount,
-        accommodationCount: trip.accommodationCount,
+        accommodationCount: trip.publicAccommodationCount,
         routeCount: trip.routeCount
       }));
     

--- a/src/app/lib/mapRouteTransform.ts
+++ b/src/app/lib/mapRouteTransform.ts
@@ -17,9 +17,14 @@ type RouteLike = {
   toCoordinates?: [number, number];
   date?: string | Date;
   departureTime?: string | Date;
+  notes?: string;
   privateNotes?: string;
   routePoints?: [number, number][];
   subRoutes?: RouteLike[];
+};
+
+type MapRouteTransformOptions = {
+  includePrivateNotes?: boolean;
 };
 
 const resolveCoords = (
@@ -40,8 +45,12 @@ const toDateString = (value?: string | Date): string | undefined => {
   return value instanceof Date ? value.toISOString() : value;
 };
 
-export const toMapRouteSegment = (route: Transportation | RouteLike): MapRouteSegment => {
+export const toMapRouteSegment = (
+  route: Transportation | RouteLike,
+  options: MapRouteTransformOptions = {}
+): MapRouteSegment => {
   const routeLike = route as RouteLike;
+  const notes = routeLike.notes || (options.includePrivateNotes ? routeLike.privateNotes : '') || '';
 
   return {
     id: routeLike.id,
@@ -52,9 +61,9 @@ export const toMapRouteSegment = (route: Transportation | RouteLike): MapRouteSe
     transportType: resolveTransportType(routeLike),
     date: resolveDate(routeLike),
     duration: '',
-    notes: routeLike.privateNotes || '',
+    notes,
     routePoints: routeLike.routePoints,
-    subRoutes: routeLike.subRoutes?.map((segment) => toMapRouteSegment(segment))
+    subRoutes: routeLike.subRoutes?.map((segment) => toMapRouteSegment(segment, options))
   };
 };
 
@@ -69,7 +78,10 @@ type MapTravelDataLike = Omit<MapTravelData, 'startDate' | 'endDate' | 'location
   routes?: Array<Transportation | RouteLike | MapRouteSegment>;
 };
 
-export const normalizeMapTravelData = (travelData: MapTravelDataLike): MapTravelData => ({
+export const normalizeMapTravelData = (
+  travelData: MapTravelDataLike,
+  options: MapRouteTransformOptions = {}
+): MapTravelData => ({
   ...travelData,
   startDate: toDateString(travelData.startDate) || '',
   endDate: toDateString(travelData.endDate) || '',
@@ -79,5 +91,5 @@ export const normalizeMapTravelData = (travelData: MapTravelDataLike): MapTravel
     date: toDateString(location.date) || '',
     endDate: toDateString(location.endDate)
   })),
-  routes: (travelData.routes || []).map(route => toMapRouteSegment(route as Transportation | RouteLike))
+  routes: (travelData.routes || []).map(route => toMapRouteSegment(route as Transportation | RouteLike, options))
 });

--- a/src/app/lib/mapShadowData.ts
+++ b/src/app/lib/mapShadowData.ts
@@ -166,9 +166,9 @@ export function buildAdminMapTravelData(
       }))
     ],
     routes: [
-      ...realRoutes.map(route => toMapRouteSegment(route)),
+      ...realRoutes.map(route => toMapRouteSegment(route, { includePrivateNotes: true })),
       ...filteredShadowRoutes.map(route => {
-        const baseRoute = toMapRouteSegment(route);
+        const baseRoute = toMapRouteSegment(route, { includePrivateNotes: true });
         return {
           ...baseRoute,
           from: `${SHADOW_LOCATION_PREFIX} ${route.from}`,
@@ -183,7 +183,7 @@ export function buildAdminMapTravelData(
     ]
   };
 
-  return normalizeMapTravelData(transformedData);
+  return transformedData;
 }
 
 export async function loadMapTravelDataForServer(

--- a/src/app/lib/unifiedDataService.ts
+++ b/src/app/lib/unifiedDataService.ts
@@ -535,6 +535,7 @@ export async function listAllTrips(): Promise<Array<{
   isUnified: boolean;
   locationCount: number;
   accommodationCount: number;
+  publicAccommodationCount: number;
   routeCount: number;
 }>> {
   try {
@@ -550,6 +551,7 @@ export async function listAllTrips(): Promise<Array<{
       isUnified: boolean;
       locationCount: number;
       accommodationCount: number;
+      publicAccommodationCount: number;
       routeCount: number;
     }>();
 
@@ -578,7 +580,11 @@ export async function listAllTrips(): Promise<Array<{
               )
             : 0);
 
-        const accommodationCount = Array.isArray(data.accommodations) ? data.accommodations.length : 0;
+        const accommodations = Array.isArray(data.accommodations) ? data.accommodations : [];
+        const accommodationCount = accommodations.length;
+        const publicAccommodationCount = accommodations.filter(
+          (accommodation: { isAccommodationPublic?: boolean }) => accommodation.isAccommodationPublic
+        ).length;
 
         trips.set(data.id, {
           id: data.id,
@@ -591,6 +597,7 @@ export async function listAllTrips(): Promise<Array<{
           isUnified: true,
           locationCount,
           accommodationCount,
+          publicAccommodationCount,
           routeCount
         });
       }


### PR DESCRIPTION
## Summary
- make map route transforms safe by default so private route notes are not copied into browser-facing map notes unless admin code explicitly opts in
- keep admin/shadow map rendering behavior by opting into private route notes on the admin map path
- report only public accommodations in the unauthenticated travel-data list response

## Security findings
- 2d6bc8c0e0148191bc17baca43cf5a51 - Public map pages leak route private notes
- 0b5f596411e481918d0891599dd4a93e - Public travel data leaks private accommodation metadata

## Verification
- bun run test:unit -- src/app/__tests__/lib/mapRouteTransform.test.ts src/app/__tests__/api/travel-data-list-privacy.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bunx eslint src/app/lib/mapRouteTransform.ts src/app/lib/mapShadowData.ts src/app/api/travel-data/list/route.ts src/app/__tests__/lib/mapRouteTransform.test.ts src/app/__tests__/api/travel-data-list-privacy.test.ts
- bun run build