### PR TITLE
Protect cost expense-link moves

### DIFF
--- a/src/app/__tests__/api/expense-links-auth.test.ts
+++ b/src/app/__tests__/api/expense-links-auth.test.ts
@@ -12,6 +12,7 @@ import {
   DELETE as deleteLegacyExpenseLink,
   POST as postLegacyExpenseLink,
 } from '@/app/api/travel-data/expense-links/route';
+import { POST as moveCostTrackingExpenseLink } from '@/app/api/cost-tracking/move-expense-link/route';
 import { POST as moveLegacyExpenseLink } from '@/app/api/travel-data/expense-links/move/route';
 
 jest.mock('@/app/lib/server-domains', () => ({
@@ -174,6 +175,21 @@ describe('expense-link API admin-domain authorization', () => {
         fromTravelItemId: 'location-1',
         toTravelItemId: 'route-1',
         toTravelItemType: 'route',
+      })
+    );
+
+    await expectForbidden(response);
+    expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
+    expect(mockSaveUnifiedTripData).not.toHaveBeenCalled();
+  });
+
+  it('blocks cost-tracking expense-link moves on public domains', async () => {
+    const response = await moveCostTrackingExpenseLink(
+      jsonRequest('https://travel.example/api/cost-tracking/move-expense-link', 'POST', {
+        tripId: 'trip-1',
+        expenseId: 'expense-1',
+        newTravelItemId: 'route-1',
+        newLinkDescription: 'Route 1',
       })
     );
 

--- a/src/app/api/cost-tracking/move-expense-link/route.ts
+++ b/src/app/api/cost-tracking/move-expense-link/route.ts
@@ -1,10 +1,28 @@
 
 import { NextResponse } from 'next/server';
 import { loadUnifiedTripData, saveUnifiedTripData } from '@/app/lib/unifiedDataService';
+import { isAdminDomain } from '@/app/lib/server-domains';
 import { CostTrackingLink } from '@/app/types';
+
+const requireAdminDomain = async (): Promise<NextResponse<{ error: string }> | null> => {
+  const isAdmin = await isAdminDomain();
+  if (isAdmin) {
+    return null;
+  }
+
+  return NextResponse.json(
+    { error: 'Forbidden - admin domain required' },
+    { status: 403 }
+  );
+};
 
 export async function POST(request: Request) {
   try {
+    const forbidden = await requireAdminDomain();
+    if (forbidden) {
+      return forbidden;
+    }
+
     const { tripId, expenseId, newTravelItemId, newLinkDescription } = await request.json();
 
     if (!tripId || !expenseId || !newTravelItemId) {


### PR DESCRIPTION
## Summary
- require admin-domain authorization before parsing or mutating /api/cost-tracking/move-expense-link
- extend the expense-link auth regression suite to cover the cost-tracking move endpoint

## Security finding
- 767f000abaec819185df2cad072b91f8 - Unauthenticated expense-link APIs allow data tampering

The other routes listed in this finding are already protected on current main by the existing expense-link auth tests; this PR closes the remaining uncovered cost-tracking move endpoint.

## Verification
- bun run test:unit -- src/app/__tests__/api/expense-links-auth.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bunx eslint src/app/api/cost-tracking/move-expense-link/route.ts src/app/__tests__/api/expense-links-auth.test.ts
- bun run build