### PR TITLE
Validate trip delete IDs

### DIFF
--- a/src/app/__tests__/api/travel-data-auth-cache.test.ts
+++ b/src/app/__tests__/api/travel-data-auth-cache.test.ts
@@ -4,8 +4,8 @@
 
 import { NextRequest } from 'next/server';
 
-import { GET, PATCH } from '@/app/api/travel-data/route';
-import { loadUnifiedTripData, updateTravelData } from '@/app/lib/unifiedDataService';
+import { DELETE, GET, PATCH } from '@/app/api/travel-data/route';
+import { deleteTripWithBackup, loadUnifiedTripData, updateTravelData } from '@/app/lib/unifiedDataService';
 
 jest.mock('@/app/lib/server-domains', () => ({
   __esModule: true,
@@ -23,6 +23,7 @@ jest.mock('@/app/lib/unifiedDataService', () => ({
 const { isAdminDomain: mockIsAdminDomain } = jest.requireMock('@/app/lib/server-domains');
 const mockLoadUnifiedTripData = loadUnifiedTripData as jest.MockedFunction<typeof loadUnifiedTripData>;
 const mockUpdateTravelData = updateTravelData as jest.MockedFunction<typeof updateTravelData>;
+const mockDeleteTripWithBackup = deleteTripWithBackup as jest.MockedFunction<typeof deleteTripWithBackup>;
 
 const buildTrip = () => ({
   schemaVersion: 4,
@@ -125,6 +126,23 @@ describe('travel-data API auth and cache boundary', () => {
     expect(result).toEqual({ error: 'Patch operation only allowed on admin domain' });
     expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
     expect(mockUpdateTravelData).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed trip IDs on DELETE before loading or deleting trip data', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+
+    const request = new NextRequest('https://admin.example.test/api/travel-data?id=victim%26x%3D1', {
+      method: 'DELETE',
+      headers: { host: 'admin.example.test' }
+    });
+
+    const response = await DELETE(request);
+    const result = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(result).toEqual({ error: 'Invalid trip ID' });
+    expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
+    expect(mockDeleteTripWithBackup).not.toHaveBeenCalled();
   });
 
   it('marks admin-domain travel data responses as private and no-store', async () => {

--- a/src/app/admin/components/TripList.tsx
+++ b/src/app/admin/components/TripList.tsx
@@ -33,6 +33,9 @@ interface TripListProps {
   } | null>>;
 }
 
+export const buildTravelDataDeleteUrl = (tripId: string): string =>
+  `/api/travel-data?${new URLSearchParams({ id: tripId }).toString()}`;
+
 export default function TripList({ tripDeleteDialog, setTripDeleteDialog }: TripListProps) {
   const router = useRouter();
   const [existingTrips, setExistingTrips] = useState<ExistingTrip[]>([]);
@@ -76,7 +79,7 @@ export default function TripList({ tripDeleteDialog, setTripDeleteDialog }: Trip
     setTripDeleteDialog(prev => prev ? { ...prev, isDeleting: true } : null);
 
     try {
-      const response = await fetch(`/api/travel-data?id=${tripDeleteDialog.tripId}`, {
+      const response = await fetch(buildTravelDataDeleteUrl(tripDeleteDialog.tripId), {
         method: 'DELETE',
         headers: { 'Content-Type': 'application/json' },
       });

--- a/src/app/admin/components/__tests__/TripList.test.ts
+++ b/src/app/admin/components/__tests__/TripList.test.ts
@@ -1,0 +1,8 @@
+import { buildTravelDataDeleteUrl } from '@/app/admin/components/TripList';
+
+describe('TripList delete URL construction', () => {
+  it('encodes trip IDs as query parameters before deletion', () => {
+    expect(buildTravelDataDeleteUrl('victim&x=1')).toBe('/api/travel-data?id=victim%26x%3D1');
+    expect(buildTravelDataDeleteUrl('victim#fragment')).toBe('/api/travel-data?id=victim%23fragment');
+  });
+});

--- a/src/app/api/travel-data/route.ts
+++ b/src/app/api/travel-data/route.ts
@@ -11,6 +11,7 @@ import { parseDateAsLocalDay } from '@/app/lib/localDateUtils';
 const DEBUG_TRAVEL_DATA = process.env.DEBUG_TRAVEL_DATA === 'true';
 const PUBLIC_TRAVEL_DATA_CACHE_CONTROL = 'public, max-age=0, s-maxage=86400, stale-while-revalidate=604800';
 const PRIVATE_TRAVEL_DATA_CACHE_CONTROL = 'no-store';
+const SAFE_TRIP_ID_PATTERN = /^[A-Za-z0-9]+$/;
 
 type RouteSegmentPayload = {
   from: string;
@@ -479,6 +480,13 @@ export async function DELETE(request: NextRequest) {
     if (!id) {
       return NextResponse.json(
         { error: 'ID parameter is required' },
+        { status: 400 }
+      );
+    }
+
+    if (!SAFE_TRIP_ID_PATTERN.test(id)) {
+      return NextResponse.json(
+        { error: 'Invalid trip ID' },
         { status: 400 }
       );
     }


### PR DESCRIPTION
## Summary
- build the admin trip-delete request URL with URLSearchParams so special characters in trip IDs cannot alter query parsing
- reject malformed trip IDs in DELETE /api/travel-data before loading or deleting any trip data
- add regression coverage for encoded delete URLs and malformed DELETE IDs

## Security finding
- a5eff21df31881918dde4f4f02ce7b35 - Unencoded trip ID can delete the wrong trip

## Verification
- bun run test:unit -- src/app/admin/components/__tests__/TripList.test.ts src/app/__tests__/api/travel-data-auth-cache.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bunx eslint src/app/admin/components/TripList.tsx src/app/admin/components/__tests__/TripList.test.ts src/app/api/travel-data/route.ts src/app/__tests__/api/travel-data-auth-cache.test.ts
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Trip deletion now validates trip IDs upfront and returns clear error messages for invalid IDs before processing. This improves error handling and provides faster user feedback.

* **Tests**
  * Added comprehensive test coverage for trip ID validation in the deletion endpoint.
  * Added test coverage for deletion URL construction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->