### PR TITLE
Limit public weather ranges

### DIFF
--- a/src/app/__tests__/api/weather-validation.test.ts
+++ b/src/app/__tests__/api/weather-validation.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+
+import { GET } from '@/app/api/weather/[...params]/route';
+
+jest.mock('@/app/services/weatherService', () => {
+  const parseWeatherDateInput = (value: string): Date | null => {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+    const parsed = new Date(`${value}T00:00:00.000Z`);
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) return null;
+    return parsed;
+  };
+
+  return {
+    MAX_LOCATION_WEATHER_SPAN_DAYS: 370,
+    parseWeatherDateInput,
+    weatherService: {
+      getWeatherForLocation: jest.fn(),
+      getWeatherForDate: jest.fn(),
+      getWeatherForecast: jest.fn(),
+    },
+  };
+});
+
+const { weatherService: mockWeatherService } = jest.requireMock('@/app/services/weatherService');
+
+const buildRequest = (path: string, query: string): NextRequest =>
+  new NextRequest(`http://localhost/api/weather/${path}?${query}`);
+
+describe('weather API validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ['invalid latitude', 'location', 'lat=91&lon=19&start=2026-01-01&end=2026-01-02'],
+    ['partial longitude', 'location', 'lat=47.5&lon=19abc&start=2026-01-01&end=2026-01-02'],
+    ['invalid start date', 'location', 'lat=47.5&lon=19&start=2026-02-30&end=2026-03-01'],
+    ['reversed location range', 'location', 'lat=47.5&lon=19&start=2026-03-02&end=2026-03-01'],
+    ['too-long location range', 'location', 'lat=47.5&lon=19&start=2026-01-01&end=2027-01-10'],
+  ])('rejects %s before calling the weather service', async (_name, path, query) => {
+    const response = await GET(buildRequest(path, query), {
+      params: Promise.resolve({ params: [path] }),
+    });
+
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(mockWeatherService.getWeatherForLocation).not.toHaveBeenCalled();
+    expect(mockWeatherService.getWeatherForDate).not.toHaveBeenCalled();
+    expect(mockWeatherService.getWeatherForecast).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed date endpoint input before calling the weather service', async () => {
+    const response = await GET(buildRequest('date', 'lat=47.5&lon=19&date=2026-01-01T00:00:00Z'), {
+      params: Promise.resolve({ params: ['date'] }),
+    });
+
+    await expect(response.json()).resolves.toMatchObject({ success: false });
+    expect(response.status).toBe(400);
+    expect(mockWeatherService.getWeatherForDate).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed forecast day counts before calling the weather service', async () => {
+    const response = await GET(buildRequest('forecast', 'lat=47.5&lon=19&days=7abc'), {
+      params: Promise.resolve({ params: ['forecast'] }),
+    });
+
+    await expect(response.json()).resolves.toMatchObject({ success: false });
+    expect(response.status).toBe(400);
+    expect(mockWeatherService.getWeatherForecast).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/__tests__/api/weather-validation.test.ts
+++ b/src/app/__tests__/api/weather-validation.test.ts
@@ -7,16 +7,10 @@ import { NextRequest } from 'next/server';
 import { GET } from '@/app/api/weather/[...params]/route';
 
 jest.mock('@/app/services/weatherService', () => {
-  const parseWeatherDateInput = (value: string): Date | null => {
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
-    const parsed = new Date(`${value}T00:00:00.000Z`);
-    if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) return null;
-    return parsed;
-  };
+  const actual = jest.requireActual('@/app/services/weatherService');
 
   return {
-    MAX_LOCATION_WEATHER_SPAN_DAYS: 370,
-    parseWeatherDateInput,
+    ...actual,
     weatherService: {
       getWeatherForLocation: jest.fn(),
       getWeatherForDate: jest.fn(),

--- a/src/app/api/weather/[...params]/route.ts
+++ b/src/app/api/weather/[...params]/route.ts
@@ -1,6 +1,38 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { weatherService } from '@/app/services/weatherService';
+import {
+  MAX_LOCATION_WEATHER_SPAN_DAYS,
+  parseWeatherDateInput,
+  weatherService
+} from '@/app/services/weatherService';
 import { Location } from '@/app/types';
+
+const coordinatePattern = /^[-+]?(?:\d+\.?\d*|\.\d+)$/;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function badRequest(error: string): NextResponse {
+  return NextResponse.json({ success: false, error }, { status: 400 });
+}
+
+function parseCoordinate(value: string | null, min: number, max: number): number | null {
+  if (value == null || value.trim() !== value || !coordinatePattern.test(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) return null;
+  return parsed;
+}
+
+function inclusiveDaySpan(start: Date, end: Date): number {
+  const startMs = Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate());
+  const endMs = Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate());
+  return Math.floor((endMs - startMs) / MS_PER_DAY) + 1;
+}
+
+function parseForecastDays(value: string | null): number | null {
+  if (value == null) return 7;
+  if (!/^\d+$/.test(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 1) return null;
+  return Math.min(16, parsed);
+}
 
 // GET /api/weather/[...params]
 // Path options:
@@ -15,11 +47,9 @@ export async function GET(
     const { params: pathParams } = await params;
     const segment = pathParams?.[0] || 'location';
     const sp = request.nextUrl.searchParams;
-    const lat = parseFloat(sp.get('lat') || '');
-    const lon = parseFloat(sp.get('lon') || '');
-    if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
-      return NextResponse.json({ success: false, error: 'lat and lon are required' }, { status: 400 });
-    }
+    const lat = parseCoordinate(sp.get('lat'), -90, 90);
+    const lon = parseCoordinate(sp.get('lon'), -180, 180);
+    if (lat == null || lon == null) return badRequest('lat and lon must be finite coordinates in valid ranges');
 
     // Server log request
     console.log('[WeatherAPI]', segment, {
@@ -35,8 +65,10 @@ export async function GET(
 
     if (segment === 'date') {
       const dateStr = sp.get('date');
-      if (!dateStr) return NextResponse.json({ success: false, error: 'date is required' }, { status: 400 });
-      const weather = await weatherService.getWeatherForDate([lat, lon], new Date(dateStr));
+      if (!dateStr) return badRequest('date is required');
+      const date = parseWeatherDateInput(dateStr);
+      if (!date) return badRequest('date must use YYYY-MM-DD');
+      const weather = await weatherService.getWeatherForDate([lat, lon], date);
       return NextResponse.json(
         { success: true, data: { dailyWeather: [weather] } },
         {
@@ -49,7 +81,8 @@ export async function GET(
     }
     
     if (segment === 'forecast') {
-      const days = Math.min(16, Math.max(1, parseInt(sp.get('days') || '7', 10)));
+      const days = parseForecastDays(sp.get('days'));
+      if (days == null) return badRequest('days must be a positive integer');
       const list = await weatherService.getWeatherForecast([lat, lon], days);
       return NextResponse.json(
         { success: true, data: { dailyWeather: list } },
@@ -65,14 +98,23 @@ export async function GET(
     // default: location range
     const start = sp.get('start');
     const end = sp.get('end');
+    const startDate = start ? parseWeatherDateInput(start) : new Date();
+    const endDate = end ? parseWeatherDateInput(end) : startDate;
+    if (!startDate) return badRequest('start must use YYYY-MM-DD');
+    if (!endDate) return badRequest('end must use YYYY-MM-DD');
+    const spanDays = inclusiveDaySpan(startDate, endDate);
+    if (spanDays < 1) return badRequest('start must be before or equal to end');
+    if (spanDays > MAX_LOCATION_WEATHER_SPAN_DAYS) {
+      return badRequest(`Weather date range cannot exceed ${MAX_LOCATION_WEATHER_SPAN_DAYS} days`);
+    }
     const name = sp.get('name') || 'Location';
     const id = sp.get('id') || `${lat.toFixed(4)},${lon.toFixed(4)}`;
     const location: Location = {
       id,
       name,
       coordinates: [lat, lon],
-      date: start ? new Date(start) : new Date(),
-      endDate: end ? new Date(end) : undefined
+      date: startDate,
+      endDate: end ? endDate : undefined
     } as Location;
     const summary = await weatherService.getWeatherForLocation(location);
     console.log('[WeatherAPI] result', { count: summary.dailyWeather.length });
@@ -90,4 +132,3 @@ export async function GET(
     return NextResponse.json({ success: false, error: err instanceof Error ? err.message : 'Unknown error' }, { status: 500 });
   }
 }
-

--- a/src/app/api/weather/[...params]/route.ts
+++ b/src/app/api/weather/[...params]/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 import {
   MAX_LOCATION_WEATHER_SPAN_DAYS,
+  daysBetweenInclusive,
   parseWeatherDateInput,
   weatherService
 } from '@/app/services/weatherService';
 import { Location } from '@/app/types';
 
 const coordinatePattern = /^[-+]?(?:\d+\.?\d*|\.\d+)$/;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 function badRequest(error: string): NextResponse {
   return NextResponse.json({ success: false, error }, { status: 400 });
@@ -18,12 +18,6 @@ function parseCoordinate(value: string | null, min: number, max: number): number
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed < min || parsed > max) return null;
   return parsed;
-}
-
-function inclusiveDaySpan(start: Date, end: Date): number {
-  const startMs = Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate());
-  const endMs = Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate());
-  return Math.floor((endMs - startMs) / MS_PER_DAY) + 1;
 }
 
 function parseForecastDays(value: string | null): number | null {
@@ -102,7 +96,7 @@ export async function GET(
     const endDate = end ? parseWeatherDateInput(end) : startDate;
     if (!startDate) return badRequest('start must use YYYY-MM-DD');
     if (!endDate) return badRequest('end must use YYYY-MM-DD');
-    const spanDays = inclusiveDaySpan(startDate, endDate);
+    const spanDays = daysBetweenInclusive(startDate, endDate);
     if (spanDays < 1) return badRequest('start must be before or equal to end');
     if (spanDays > MAX_LOCATION_WEATHER_SPAN_DAYS) {
       return badRequest(`Weather date range cannot exceed ${MAX_LOCATION_WEATHER_SPAN_DAYS} days`);

--- a/src/app/services/__tests__/weatherService.validation.test.ts
+++ b/src/app/services/__tests__/weatherService.validation.test.ts
@@ -1,0 +1,54 @@
+/** @jest-environment node */
+
+import fs from 'fs/promises';
+
+import { weatherService } from '@/app/services/weatherService';
+import { Location } from '@/app/types';
+
+function buildLocation(overrides?: Partial<Location>): Location {
+  return {
+    id: 'loc-1',
+    name: 'Budapest',
+    coordinates: [47.4979, 19.0402],
+    date: new Date('2026-01-01T00:00:00.000Z'),
+    endDate: new Date('2027-01-10T00:00:00.000Z'),
+    ...overrides,
+  } as Location;
+}
+
+describe('weatherService validation', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('rejects oversized location ranges before cache or fetch work', async () => {
+    const mkdirSpy = jest.spyOn(fs, 'mkdir');
+    const readFileSpy = jest.spyOn(fs, 'readFile');
+    const writeFileSpy = jest.spyOn(fs, 'writeFile');
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    await expect(weatherService.getWeatherForLocation(buildLocation())).rejects.toThrow(
+      'Weather date range cannot exceed 370 days'
+    );
+
+    expect(mkdirSpy).not.toHaveBeenCalled();
+    expect(readFileSpy).not.toHaveBeenCalled();
+    expect(writeFileSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid coordinates before cache or fetch work', async () => {
+    const mkdirSpy = jest.spyOn(fs, 'mkdir');
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    await expect(
+      weatherService.getWeatherForLocation(buildLocation({
+        coordinates: [Number.POSITIVE_INFINITY, 19.0402],
+        endDate: new Date('2026-01-02T00:00:00.000Z'),
+      }))
+    ).rejects.toThrow('Invalid coordinates');
+
+    expect(mkdirSpy).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/services/weatherService.ts
+++ b/src/app/services/weatherService.ts
@@ -32,6 +32,8 @@ let rateLimitBackoffUntil = 0;
 let rateLimitQueue: Promise<void> = Promise.resolve();
 
 const OPEN_METEO_ARCHIVE_MIN_DATE = new Date(Date.UTC(2016, 0, 1));
+export const MAX_LOCATION_WEATHER_SPAN_DAYS = 370;
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
  * Ensure the local data directory exists by creating it and any missing parent directories.
@@ -48,6 +50,43 @@ function log(...args: unknown[]) {
 
 function toISODate(date: Date): string {
   return formatISO(date, { representation: 'date' });
+}
+
+function parseStrictISODate(value: string): Date | null {
+  if (!ISO_DATE_RE.test(value)) return null;
+  const parsed = parseISO(value);
+  if (!isValid(parsed) || toISODate(parsed) !== value) return null;
+  return parsed;
+}
+
+function validateCoordinates(coords: [number, number]): void {
+  const [lat, lon] = coords;
+  if (!Number.isFinite(lat) || !Number.isFinite(lon) || lat < -90 || lat > 90 || lon < -180 || lon > 180) {
+    throw new Error('Invalid coordinates');
+  }
+}
+
+function validateDateRange(start: Date, end: Date): { startISO: string; endISO: string; spanDays: number } {
+  if (!isValid(start) || !isValid(end)) {
+    throw new Error('Invalid weather date range');
+  }
+
+  const startISO = toISODate(start);
+  const endISO = toISODate(end);
+  const spanDays = daysBetweenInclusive(parseISO(startISO), parseISO(endISO));
+
+  if (spanDays < 1) {
+    throw new Error('Weather start date must be before or equal to end date');
+  }
+  if (spanDays > MAX_LOCATION_WEATHER_SPAN_DAYS) {
+    throw new Error(`Weather date range cannot exceed ${MAX_LOCATION_WEATHER_SPAN_DAYS} days`);
+  }
+
+  return { startISO, endISO, spanDays };
+}
+
+export function parseWeatherDateInput(value: string): Date | null {
+  return parseStrictISODate(value);
 }
 
 async function sleep(ms: number): Promise<void> {
@@ -659,12 +698,10 @@ class WeatherService {
     location: Location,
     options?: { preferCache?: boolean }
   ): Promise<WeatherSummary> {
+    validateCoordinates(location.coordinates);
     const start = location.date ? new Date(location.date) : new Date();
     const end = location.endDate ? new Date(location.endDate) : start;
-    const clampedStart = start;
-    const clampedEnd = end;
-    const startISO = toISODate(clampedStart);
-    const endISO = toISODate(clampedEnd);
+    const { startISO, endISO } = validateDateRange(start, end);
     const key = buildCacheKey(location.coordinates, startISO, endISO);
     const preferCache = options?.preferCache === true;
 
@@ -750,6 +787,10 @@ class WeatherService {
   }
 
   async getWeatherForDate(coords: [number, number], date: Date): Promise<WeatherData> {
+    validateCoordinates(coords);
+    if (!isValid(date)) {
+      throw new Error('Invalid weather date');
+    }
     const dayISO = toISODate(date);
     const dayAsLocalDate = parseISO(dayISO);
     const [lat, lon] = coords;
@@ -784,6 +825,10 @@ class WeatherService {
   }
 
   async getWeatherForecast(coords: [number, number], days: number): Promise<WeatherData[]> {
+    validateCoordinates(coords);
+    if (!Number.isFinite(days)) {
+      throw new Error('Invalid forecast day count');
+    }
     const start = new Date();
     const end = addDays(start, Math.max(1, Math.min(16, days)) - 1);
     return fetchOpenMeteoRangeSmart(coords, toISODate(start), toISODate(end));
@@ -796,6 +841,7 @@ export const weatherServiceTestUtils = {
   parseRateLimitResetMs,
   getRateLimitHeaderDelayMs,
   needsForecastRefresh,
+  parseWeatherDateInput,
   resetRateLimitStateForTests
 };
 

--- a/src/app/services/weatherService.ts
+++ b/src/app/services/weatherService.ts
@@ -559,7 +559,7 @@ function safeDate(year: number, month: number, day: number): Date {
   return d;
 }
 
-function daysBetweenInclusive(start: Date, end: Date): number {
+export function daysBetweenInclusive(start: Date, end: Date): number {
   const s = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate()));
   const e = new Date(Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate()));
   const ms = e.getTime() - s.getTime();
@@ -841,7 +841,6 @@ export const weatherServiceTestUtils = {
   parseRateLimitResetMs,
   getRateLimitHeaderDelayMs,
   needsForecastRefresh,
-  parseWeatherDateInput,
   resetRateLimitStateForTests
 };
 

--- a/src/app/services/weatherService.ts
+++ b/src/app/services/weatherService.ts
@@ -66,14 +66,14 @@ function validateCoordinates(coords: [number, number]): void {
   }
 }
 
-function validateDateRange(start: Date, end: Date): { startISO: string; endISO: string; spanDays: number } {
+function validateDateRange(start: Date, end: Date): { startISO: string; endISO: string } {
   if (!isValid(start) || !isValid(end)) {
     throw new Error('Invalid weather date range');
   }
 
   const startISO = toISODate(start);
   const endISO = toISODate(end);
-  const spanDays = daysBetweenInclusive(parseISO(startISO), parseISO(endISO));
+  const spanDays = daysBetweenInclusive(start, end);
 
   if (spanDays < 1) {
     throw new Error('Weather start date must be before or equal to end date');
@@ -82,7 +82,7 @@ function validateDateRange(start: Date, end: Date): { startISO: string; endISO: 
     throw new Error(`Weather date range cannot exceed ${MAX_LOCATION_WEATHER_SPAN_DAYS} days`);
   }
 
-  return { startISO, endISO, spanDays };
+  return { startISO, endISO };
 }
 
 export function parseWeatherDateInput(value: string): Date | null {


### PR DESCRIPTION
## Summary
- validate public weather coordinates, strict date inputs, date ordering, forecast day counts, and location-range spans before calling weather services
- add service-level guards so excessive or invalid weather ranges fail before cache, fetch, missing-date fill, or historical-average work
- add regression coverage for the weather API boundary and service guard behavior

Security findings covered:
- 945769b946988191b82b3b20fbe07483
- 6b4212dc24788191a680d6e62b45a8bc
- 7fc9ac50960081919679847b75e8d1e3
- b6c6c97f291c819192166397023afc06

## Verification
- bun run test:unit -- src/app/__tests__/api/weather-validation.test.ts src/app/services/__tests__/weatherService.validation.test.ts src/app/services/__tests__/weatherService.rateLimit.test.ts src/app/services/__tests__/weatherService.refreshPolicy.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint 'src/app/api/weather/[...params]/route.ts' src/app/services/weatherService.ts src/app/__tests__/api/weather-validation.test.ts src/app/services/__tests__/weatherService.validation.test.ts --max-warnings=0
- bun run build