### PR TITLE
Harden Wikipedia API boundary

### DIFF
--- a/src/app/__tests__/api/wikipedia-boundary.test.ts
+++ b/src/app/__tests__/api/wikipedia-boundary.test.ts
@@ -128,6 +128,8 @@ describe('wikipedia API boundary', () => {
   });
 
   it('rejects malformed public location coordinates before calling the service', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+
     const request = buildRequest(
       'https://public.example.test/api/wikipedia/Paris?lat=48.8566&lon=2.3522evil'
     );
@@ -195,6 +197,22 @@ describe('wikipedia API boundary', () => {
 
     expect(putResponse.status).toBe(403);
     expect(deleteResponse.status).toBe(403);
+    expect(mockGetLocationData).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for malformed admin PUT JSON instead of 500', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+
+    const request = buildRequest('https://admin.example.test/api/wikipedia/Paris', {
+      method: 'PUT',
+      body: '{',
+    });
+    const response = await PUT_WIKIPEDIA_LOCATION(request, routeParams());
+
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
     expect(mockGetLocationData).not.toHaveBeenCalled();
   });
 });

--- a/src/app/__tests__/api/wikipedia-boundary.test.ts
+++ b/src/app/__tests__/api/wikipedia-boundary.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+
+import {
+  DELETE as DELETE_WIKIPEDIA_LOCATION,
+  GET as GET_WIKIPEDIA_LOCATION,
+  PUT as PUT_WIKIPEDIA_LOCATION,
+} from '@/app/api/wikipedia/[locationName]/route';
+import {
+  GET as GET_WIKIPEDIA_REFRESH,
+  POST as POST_WIKIPEDIA_REFRESH,
+} from '@/app/api/wikipedia/refresh/route';
+import { wikipediaService } from '@/app/services/wikipediaService';
+import { listAllTrips, loadUnifiedTripData } from '@/app/lib/unifiedDataService';
+
+jest.mock('@/app/lib/server-domains', () => ({
+  __esModule: true,
+  isAdminDomain: jest.fn(),
+}));
+
+jest.mock('@/app/services/wikipediaService', () => ({
+  __esModule: true,
+  wikipediaService: {
+    getLocationData: jest.fn(),
+    getCachedData: jest.fn(),
+    fetchLocationData: jest.fn(),
+    listCachedFiles: jest.fn(),
+  },
+}));
+
+jest.mock('@/app/lib/unifiedDataService', () => ({
+  __esModule: true,
+  listAllTrips: jest.fn(),
+  loadUnifiedTripData: jest.fn(),
+}));
+
+const { isAdminDomain: mockIsAdminDomain } = jest.requireMock('@/app/lib/server-domains');
+const mockGetLocationData = wikipediaService.getLocationData as jest.MockedFunction<typeof wikipediaService.getLocationData>;
+const mockGetCachedData = wikipediaService.getCachedData as jest.MockedFunction<typeof wikipediaService.getCachedData>;
+const mockFetchLocationData = wikipediaService.fetchLocationData as jest.MockedFunction<typeof wikipediaService.fetchLocationData>;
+const mockListCachedFiles = wikipediaService.listCachedFiles as jest.MockedFunction<typeof wikipediaService.listCachedFiles>;
+const mockListAllTrips = listAllTrips as jest.MockedFunction<typeof listAllTrips>;
+const mockLoadUnifiedTripData = loadUnifiedTripData as jest.MockedFunction<typeof loadUnifiedTripData>;
+
+const routeParams = (locationName = 'Paris') => ({
+  params: Promise.resolve({ locationName }),
+});
+
+const buildRequest = (url: string, init?: RequestInit): NextRequest => new NextRequest(url, init);
+
+describe('wikipedia API boundary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetLocationData.mockResolvedValue({
+      title: 'Paris',
+      extract: 'Paris is a city.',
+      url: 'https://en.wikipedia.org/wiki/Paris',
+      attribution: {
+        text: 'Source: Wikipedia',
+        url: 'https://en.wikipedia.org/wiki/Paris',
+        license: 'CC BY-SA 4.0',
+        imageDisclaimer: 'Image licensing: verify on Wikipedia',
+      },
+      lastFetched: Date.now(),
+      refreshStatus: 'success',
+      cacheKey: 'paris.json',
+      apiVersion: 'rest_v1',
+    });
+    mockGetCachedData.mockResolvedValue({
+      title: 'Paris',
+      extract: 'Paris is a city.',
+      url: 'https://en.wikipedia.org/wiki/Paris',
+      attribution: {
+        text: 'Source: Wikipedia',
+        url: 'https://en.wikipedia.org/wiki/Paris',
+        license: 'CC BY-SA 4.0',
+        imageDisclaimer: 'Image licensing: verify on Wikipedia',
+      },
+      lastFetched: Date.now(),
+      refreshStatus: 'success',
+      cacheKey: 'paris.json',
+      apiVersion: 'rest_v1',
+    });
+    mockFetchLocationData.mockResolvedValue(null);
+    mockListCachedFiles.mockResolvedValue([]);
+    mockListAllTrips.mockResolvedValue([]);
+    mockLoadUnifiedTripData.mockResolvedValue(null);
+  });
+
+  it('rejects public refresh status before reading cache metadata', async () => {
+    mockIsAdminDomain.mockResolvedValue(false);
+
+    const response = await GET_WIKIPEDIA_REFRESH();
+
+    expect(response.status).toBe(403);
+    expect(mockListCachedFiles).not.toHaveBeenCalled();
+  });
+
+  it('rejects public batch refresh before parsing body or loading trip data', async () => {
+    mockIsAdminDomain.mockResolvedValue(false);
+
+    const request = buildRequest('https://public.example.test/api/wikipedia/refresh', {
+      method: 'POST',
+      body: '{',
+    });
+    const response = await POST_WIKIPEDIA_REFRESH(request);
+
+    expect(response.status).toBe(403);
+    expect(mockListAllTrips).not.toHaveBeenCalled();
+    expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
+    expect(mockFetchLocationData).not.toHaveBeenCalled();
+  });
+
+  it('rejects public forced per-location refresh before calling the service', async () => {
+    mockIsAdminDomain.mockResolvedValue(false);
+
+    const request = buildRequest(
+      'https://public.example.test/api/wikipedia/Paris?lat=48.8566&lon=2.3522&refresh=true'
+    );
+    const response = await GET_WIKIPEDIA_LOCATION(request, routeParams());
+
+    expect(response.status).toBe(403);
+    expect(mockGetLocationData).not.toHaveBeenCalled();
+    expect(mockGetCachedData).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed public location coordinates before calling the service', async () => {
+    const request = buildRequest(
+      'https://public.example.test/api/wikipedia/Paris?lat=48.8566&lon=2.3522evil'
+    );
+    const response = await GET_WIKIPEDIA_LOCATION(request, routeParams());
+
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(mockGetLocationData).not.toHaveBeenCalled();
+    expect(mockIsAdminDomain).not.toHaveBeenCalled();
+  });
+
+  it('serves normal public location lookup from cache only', async () => {
+    mockIsAdminDomain.mockResolvedValue(false);
+
+    const request = buildRequest(
+      'https://public.example.test/api/wikipedia/Paris?lat=48.8566&lon=2.3522&wikipediaRef=Paris'
+    );
+    const response = await GET_WIKIPEDIA_LOCATION(request, routeParams());
+
+    expect(response.status).toBe(200);
+    expect(mockGetLocationData).not.toHaveBeenCalled();
+    expect(mockGetCachedData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Paris',
+        coordinates: [48.8566, 2.3522],
+        wikipediaRef: 'Paris',
+      })
+    );
+  });
+
+  it('allows admin forced per-location refresh', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+
+    const request = buildRequest(
+      'https://admin.example.test/api/wikipedia/Paris?lat=48.8566&lon=2.3522&refresh=true'
+    );
+    const response = await GET_WIKIPEDIA_LOCATION(request, routeParams());
+
+    expect(response.status).toBe(200);
+    expect(mockGetLocationData).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Paris' }),
+      true,
+      undefined
+    );
+  });
+
+  it('rejects public PUT and DELETE before mutation work', async () => {
+    mockIsAdminDomain.mockResolvedValue(false);
+
+    const putRequest = buildRequest('https://public.example.test/api/wikipedia/Paris', {
+      method: 'PUT',
+      body: JSON.stringify({
+        wikipediaRef: 'Paris',
+        coordinates: [48.8566, 2.3522],
+      }),
+    });
+    const deleteRequest = buildRequest('https://public.example.test/api/wikipedia/Paris', {
+      method: 'DELETE',
+    });
+
+    const putResponse = await PUT_WIKIPEDIA_LOCATION(putRequest, routeParams());
+    const deleteResponse = await DELETE_WIKIPEDIA_LOCATION(deleteRequest, routeParams());
+
+    expect(putResponse.status).toBe(403);
+    expect(deleteResponse.status).toBe(403);
+    expect(mockGetLocationData).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/wikipedia/[locationName]/route.ts
+++ b/src/app/api/wikipedia/[locationName]/route.ts
@@ -6,16 +6,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { wikipediaService } from '@/app/services/wikipediaService';
 import { isAdminDomain } from '@/app/lib/server-domains';
+import { requireAdminDomain } from '@/app/lib/adminRouteGuard';
 
 const MAX_LOCATION_NAME_LENGTH = 120;
 const MAX_WIKIPEDIA_REF_LENGTH = 160;
 const coordinatePattern = /^[-+]?(?:\d+\.?\d*|\.\d+)$/;
-
-const requireAdminDomain = async (): Promise<NextResponse<{ error: string }> | null> => {
-  const isAdmin = await isAdminDomain();
-  if (isAdmin) return null;
-  return NextResponse.json({ error: 'Admin domain required' }, { status: 403 });
-};
 
 function badRequest(error: string): NextResponse {
   return NextResponse.json({ success: false, error }, { status: 400 });
@@ -157,15 +152,16 @@ export async function PUT(
   { params }: { params: Promise<{ locationName: string }> }
 ): Promise<NextResponse> {
   try {
-    const { locationName: rawLocationName } = await params;
-    const locationName = decodeURIComponent(rawLocationName);
     const forbidden = await requireAdminDomain();
     if (forbidden) return forbidden;
+
+    const { locationName: rawLocationName } = await params;
+    const locationName = decodeURIComponent(rawLocationName);
 
     const locationNameError = validateLocationName(locationName);
     if (locationNameError) return locationNameError;
 
-    const body = await request.json();
+    const body = await request.json().catch(() => ({}));
     const locale = request.headers.get('accept-language')?.split(',')[0]?.trim();
     
     const { wikipediaRef, coordinates } = body;

--- a/src/app/api/wikipedia/[locationName]/route.ts
+++ b/src/app/api/wikipedia/[locationName]/route.ts
@@ -5,6 +5,54 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { wikipediaService } from '@/app/services/wikipediaService';
+import { isAdminDomain } from '@/app/lib/server-domains';
+
+const MAX_LOCATION_NAME_LENGTH = 120;
+const MAX_WIKIPEDIA_REF_LENGTH = 160;
+const coordinatePattern = /^[-+]?(?:\d+\.?\d*|\.\d+)$/;
+
+const requireAdminDomain = async (): Promise<NextResponse<{ error: string }> | null> => {
+  const isAdmin = await isAdminDomain();
+  if (isAdmin) return null;
+  return NextResponse.json({ error: 'Admin domain required' }, { status: 403 });
+};
+
+function badRequest(error: string): NextResponse {
+  return NextResponse.json({ success: false, error }, { status: 400 });
+}
+
+function parseCoordinate(value: string | null, min: number, max: number): number | null {
+  if (value == null || value.trim() !== value || !coordinatePattern.test(value)) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) return null;
+  return parsed;
+}
+
+function parseCoordinates(lat: string | null, lon: string | null): [number, number] | null {
+  const parsedLat = parseCoordinate(lat, -90, 90);
+  const parsedLon = parseCoordinate(lon, -180, 180);
+  if (parsedLat == null || parsedLon == null) return null;
+  return [parsedLat, parsedLon];
+}
+
+function validateLocationName(locationName: string): NextResponse | null {
+  const trimmed = locationName.trim();
+  if (trimmed.length === 0) return badRequest('Location name is required');
+  if (trimmed.length > MAX_LOCATION_NAME_LENGTH) {
+    return badRequest(`Location name cannot exceed ${MAX_LOCATION_NAME_LENGTH} characters`);
+  }
+  return null;
+}
+
+function validateWikipediaRef(wikipediaRef: string | null): NextResponse | null {
+  if (wikipediaRef == null) return null;
+  const trimmed = wikipediaRef.trim();
+  if (trimmed.length === 0) return badRequest('Wikipedia reference cannot be blank');
+  if (trimmed.length > MAX_WIKIPEDIA_REF_LENGTH) {
+    return badRequest(`Wikipedia reference cannot exceed ${MAX_WIKIPEDIA_REF_LENGTH} characters`);
+  }
+  return null;
+}
 
 /**
  * GET /api/wikipedia/[locationName]
@@ -20,12 +68,8 @@ export async function GET(
     const { locationName: rawLocationName } = await params;
     locationName = decodeURIComponent(rawLocationName);
     
-    if (!locationName || locationName.trim().length === 0) {
-      return NextResponse.json({
-        success: false,
-        error: 'Location name is required',
-      }, { status: 400 });
-    }
+    const locationNameError = validateLocationName(locationName);
+    if (locationNameError) return locationNameError;
 
     // Parse query parameters
     const searchParams = request.nextUrl.searchParams;
@@ -33,6 +77,19 @@ export async function GET(
     const lon = searchParams.get('lon');
     const forceRefresh = searchParams.get('refresh') === 'true';
     const wikipediaRef = searchParams.get('wikipediaRef');
+    const coordinates = parseCoordinates(lat, lon);
+
+    if (!coordinates) {
+      return badRequest('lat and lon must be finite coordinates in valid ranges');
+    }
+
+    const wikipediaRefError = validateWikipediaRef(wikipediaRef);
+    if (wikipediaRefError) return wikipediaRefError;
+
+    const isAdminRequest = await isAdminDomain();
+    if (forceRefresh && !isAdminRequest) {
+      return NextResponse.json({ error: 'Admin domain required' }, { status: 403 });
+    }
 
     const locale = request.headers.get('accept-language')?.split(',')[0]?.trim();
 
@@ -40,13 +97,16 @@ export async function GET(
     const location = {
       id: 'temp-id', // Temporary ID for API calls
       name: locationName,
-      coordinates: (lat && lon) ? [parseFloat(lat), parseFloat(lon)] as [number, number] : [0, 0] as [number, number],
-      wikipediaRef: wikipediaRef || undefined,
+      coordinates,
+      wikipediaRef: wikipediaRef?.trim() || undefined,
       date: new Date(), // Required by Location type
     };
 
-    // Get Wikipedia data (cached or fresh)
-    const wikipediaData = await wikipediaService.getLocationData(location, forceRefresh, locale);
+    // Public requests are cache-only to avoid turning the public API into an
+    // unauthenticated Wikipedia fetch-and-write proxy.
+    const wikipediaData = isAdminRequest
+      ? await wikipediaService.getLocationData(location, forceRefresh, locale)
+      : await wikipediaService.getCachedData(location);
 
     if (!wikipediaData) {
       return NextResponse.json({
@@ -99,24 +159,39 @@ export async function PUT(
   try {
     const { locationName: rawLocationName } = await params;
     const locationName = decodeURIComponent(rawLocationName);
+    const forbidden = await requireAdminDomain();
+    if (forbidden) return forbidden;
+
+    const locationNameError = validateLocationName(locationName);
+    if (locationNameError) return locationNameError;
+
     const body = await request.json();
     const locale = request.headers.get('accept-language')?.split(',')[0]?.trim();
     
     const { wikipediaRef, coordinates } = body;
 
-    if (!wikipediaRef) {
-      return NextResponse.json({
-        success: false,
-        error: 'Wikipedia reference is required',
-      }, { status: 400 });
+    if (typeof wikipediaRef !== 'string') {
+      return badRequest('Wikipedia reference is required');
+    }
+
+    const wikipediaRefError = validateWikipediaRef(wikipediaRef);
+    if (wikipediaRefError) return wikipediaRefError;
+
+    if (!Array.isArray(coordinates) || coordinates.length !== 2) {
+      return badRequest('coordinates are required');
+    }
+
+    const parsedCoordinates = parseCoordinates(String(coordinates[0]), String(coordinates[1]));
+    if (!parsedCoordinates) {
+      return badRequest('coordinates must be finite coordinates in valid ranges');
     }
 
     // Build location object with new reference
     const location = {
       id: 'temp-id',
       name: locationName,
-      coordinates: coordinates as [number, number] || [0, 0] as [number, number],
-      wikipediaRef,
+      coordinates: parsedCoordinates,
+      wikipediaRef: wikipediaRef.trim(),
       date: new Date(),
     };
 
@@ -157,8 +232,13 @@ export async function DELETE(
   { params }: { params: Promise<{ locationName: string }> }
 ): Promise<NextResponse> {
   try {
+    const forbidden = await requireAdminDomain();
+    if (forbidden) return forbidden;
+
     const { locationName: rawLocationName } = await params;
     const locationName = decodeURIComponent(rawLocationName);
+    const locationNameError = validateLocationName(locationName);
+    if (locationNameError) return locationNameError;
     
     // TODO: Implement cache deletion in WikipediaService
     // For now, return success

--- a/src/app/api/wikipedia/refresh/route.ts
+++ b/src/app/api/wikipedia/refresh/route.ts
@@ -16,12 +16,19 @@ import {
 import fs from 'fs/promises';
 import path from 'path';
 import { getDataDir } from '@/app/lib/dataDirectory';
+import { isAdminDomain } from '@/app/lib/server-domains';
 
 const DEFAULT_REFRESH_CONFIG: RefreshJobConfig = {
   batchSize: 20, // Process 20 locations at a time
   delayBetweenRequests: 100, // 100ms delay between requests
   maxRetries: 3,
   timeoutMs: 30000, // 30 second timeout per location
+};
+
+const requireAdminDomain = async (): Promise<NextResponse<{ error: string }> | null> => {
+  const isAdmin = await isAdminDomain();
+  if (isAdmin) return null;
+  return NextResponse.json({ error: 'Admin domain required' }, { status: 403 });
 };
 
 /**
@@ -171,9 +178,12 @@ async function processLocation(
  * Refresh Wikipedia data for all locations
  */
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  console.log('Starting Wikipedia refresh job...');
-  
   try {
+    const forbidden = await requireAdminDomain();
+    if (forbidden) return forbidden;
+
+    console.log('Starting Wikipedia refresh job...');
+
     // Parse request body for configuration overrides
     const body = await request.json().catch(() => ({}));
     const config: RefreshJobConfig = { ...DEFAULT_REFRESH_CONFIG, ...body.config };
@@ -328,6 +338,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
  */
 export async function GET(): Promise<NextResponse> {
   try {
+    const forbidden = await requireAdminDomain();
+    if (forbidden) return forbidden;
+
     const metadata = await loadWikipediaMetadata();
     const cachedFiles = await wikipediaService.listCachedFiles();
     

--- a/src/app/api/wikipedia/refresh/route.ts
+++ b/src/app/api/wikipedia/refresh/route.ts
@@ -16,19 +16,13 @@ import {
 import fs from 'fs/promises';
 import path from 'path';
 import { getDataDir } from '@/app/lib/dataDirectory';
-import { isAdminDomain } from '@/app/lib/server-domains';
+import { requireAdminDomain } from '@/app/lib/adminRouteGuard';
 
 const DEFAULT_REFRESH_CONFIG: RefreshJobConfig = {
   batchSize: 20, // Process 20 locations at a time
   delayBetweenRequests: 100, // 100ms delay between requests
   maxRetries: 3,
   timeoutMs: 30000, // 30 second timeout per location
-};
-
-const requireAdminDomain = async (): Promise<NextResponse<{ error: string }> | null> => {
-  const isAdmin = await isAdminDomain();
-  if (isAdmin) return null;
-  return NextResponse.json({ error: 'Admin domain required' }, { status: 403 });
 };
 
 /**

--- a/src/app/lib/adminRouteGuard.ts
+++ b/src/app/lib/adminRouteGuard.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { isAdminDomain } from '@/app/lib/server-domains';
+
+export async function requireAdminDomain(): Promise<NextResponse<{ error: string }> | null> {
+  const isAdmin = await isAdminDomain();
+  if (isAdmin) return null;
+  return NextResponse.json({ error: 'Admin domain required' }, { status: 403 });
+}


### PR DESCRIPTION
## Summary
- require admin-domain access for Wikipedia refresh status and batch refresh endpoints before body parsing, metadata reads, or trip-data loading
- require admin-domain access for per-location forced refresh and mutation endpoints
- make public per-location Wikipedia lookups cache-only with bounded location, reference, and coordinate inputs
- add regression coverage proving public requests fail before expensive refresh/fetch/cache work

Security finding covered:
- 6fcc11d8ae908191be6346532fc222b0

## Verification
- bun run test:unit -- src/app/__tests__/api/wikipedia-boundary.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint 'src/app/api/wikipedia/[locationName]/route.ts' src/app/api/wikipedia/refresh/route.ts src/app/__tests__/api/wikipedia-boundary.test.ts --max-warnings=0
- bun run build