### PR TITLE
Keep sensitive admin data out of browser storage

### DIFF
--- a/src/app/__tests__/lib/costTrackerCache.test.ts
+++ b/src/app/__tests__/lib/costTrackerCache.test.ts
@@ -41,17 +41,36 @@ describe('costTrackerCache', () => {
     expect(getCachedCostTracker('cost-trip-1')).toEqual(expectedCachedData);
   });
 
-  it('restores cached data from sessionStorage after memory cache is cleared', () => {
-    const costData = buildCostData('cost-trip-1');
+  it('does not persist full cost tracker data to sessionStorage', () => {
+    const costData = {
+      ...buildCostData('cost-trip-1'),
+      ynabConfig: {
+        apiKey: 'SECRET_YNAB_KEY',
+        selectedBudgetId: 'budget-1'
+      }
+    };
+    const expectedCachedData = { ...costData, id: 'cost-trip-1' };
 
     setCachedCostTracker(costData);
-    clearCachedCostTracker('cost-trip-1');
+
+    expect(window.sessionStorage.getItem('travel-tracker-cost-cache:cost-trip-1')).toBeNull();
+    expect(getCachedCostTracker('cost-trip-1')).toEqual(expectedCachedData);
+  });
+
+  it('removes legacy persisted cost tracker data when checked', () => {
     window.sessionStorage.setItem(
       'travel-tracker-cost-cache:cost-trip-1',
-      JSON.stringify(costData)
+      JSON.stringify({
+        ...buildCostData('cost-trip-1'),
+        ynabConfig: {
+          apiKey: 'SECRET_YNAB_KEY',
+          selectedBudgetId: 'budget-1'
+        }
+      })
     );
 
-    expect(getCachedCostTracker('cost-trip-1')).toEqual(costData);
+    expect(getCachedCostTracker('cost-trip-1')).toBeNull();
+    expect(window.sessionStorage.getItem('travel-tracker-cost-cache:cost-trip-1')).toBeNull();
   });
 
   it('ignores incomplete cost tracker entries without an id or trip id', () => {

--- a/src/app/__tests__/lib/offlineDeltaSync.test.ts
+++ b/src/app/__tests__/lib/offlineDeltaSync.test.ts
@@ -160,6 +160,50 @@ describe('offlineDeltaSync', () => {
     expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: 'PATCH' });
   });
 
+  it('redacts YNAB API keys from queued cost data in localStorage', () => {
+    const base = makeCostData({
+      ynabConfig: {
+        apiKey: 'SECRET_BASE_YNAB_KEY',
+        selectedBudgetId: 'budget-1'
+      }
+    });
+    const pending = makeCostData({
+      overallBudget: 1500,
+      ynabConfig: {
+        apiKey: 'SECRET_PENDING_YNAB_KEY',
+        selectedBudgetId: 'budget-2'
+      }
+    });
+
+    const queued = queueCostDelta({
+      id: base.id,
+      baseSnapshot: base,
+      pendingSnapshot: pending
+    });
+
+    expect(queued.queued).toBe(true);
+    const serializedQueue = localStorage.getItem('travel-tracker-offline-delta-queue-v1');
+    expect(serializedQueue).not.toContain('SECRET_BASE_YNAB_KEY');
+    expect(serializedQueue).not.toContain('SECRET_PENDING_YNAB_KEY');
+
+    const [entry] = getOfflineQueueEntries();
+    expect(entry).toMatchObject({
+      kind: 'cost',
+      baseSnapshot: {
+        ynabConfig: {
+          hasApiKey: true,
+          selectedBudgetId: 'budget-1'
+        }
+      },
+      pendingSnapshot: {
+        ynabConfig: {
+          hasApiKey: true,
+          selectedBudgetId: 'budget-2'
+        }
+      }
+    });
+  });
+
   it('discards conflicted queue entries when requested', async () => {
     const base = makeTravelData();
     const pending = makeTravelData({ title: 'Offline Title Change' });

--- a/src/app/__tests__/lib/offlineDeltaSync.test.ts
+++ b/src/app/__tests__/lib/offlineDeltaSync.test.ts
@@ -135,8 +135,19 @@ describe('offlineDeltaSync', () => {
   });
 
   it('syncs queued cost delta when server base has not changed', async () => {
-    const base = makeCostData();
-    const pending = makeCostData({ overallBudget: 1500 });
+    const base = makeCostData({
+      ynabConfig: {
+        apiKey: 'SECRET_SYNC_YNAB_KEY',
+        selectedBudgetId: 'budget-1'
+      }
+    });
+    const pending = makeCostData({
+      overallBudget: 1500,
+      ynabConfig: {
+        apiKey: 'SECRET_SYNC_YNAB_KEY',
+        selectedBudgetId: 'budget-1'
+      }
+    });
 
     const queued = queueCostDelta({
       id: base.id,
@@ -158,6 +169,7 @@ describe('offlineDeltaSync', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls[1][0]).toContain('/api/cost-tracking?id=');
     expect(fetchMock.mock.calls[1][1]).toMatchObject({ method: 'PATCH' });
+    expect(JSON.stringify(fetchMock.mock.calls[1][1])).not.toContain('SECRET_SYNC_YNAB_KEY');
   });
 
   it('redacts YNAB API keys from queued cost data in localStorage', () => {

--- a/src/app/__tests__/lib/travelDataCache.test.ts
+++ b/src/app/__tests__/lib/travelDataCache.test.ts
@@ -31,16 +31,26 @@ describe('travelDataCache', () => {
     expect(getCachedTravelData('trip-1')).toEqual(travelData);
   });
 
-  it('restores cached data from sessionStorage after memory cache is cleared', () => {
+  it('does not persist full trip data to sessionStorage', () => {
     const travelData = buildTravelData('trip-1');
 
     setCachedTravelData(travelData);
-    clearCachedTravelData('trip-1');
+
+    expect(window.sessionStorage.getItem('travel-tracker-trip-cache:trip-1')).toBeNull();
+    expect(getCachedTravelData('trip-1')).toEqual(travelData);
+  });
+
+  it('removes legacy persisted trip data when checked', () => {
+    const travelData = buildTravelData('trip-1');
     window.sessionStorage.setItem(
       'travel-tracker-trip-cache:trip-1',
-      JSON.stringify(travelData)
+      JSON.stringify({
+        ...travelData,
+        privateNotes: 'do not keep in browser storage'
+      })
     );
 
-    expect(getCachedTravelData('trip-1')).toEqual(travelData);
+    expect(getCachedTravelData('trip-1')).toBeNull();
+    expect(window.sessionStorage.getItem('travel-tracker-trip-cache:trip-1')).toBeNull();
   });
 });

--- a/src/app/lib/costTrackerCache.ts
+++ b/src/app/lib/costTrackerCache.ts
@@ -26,23 +26,8 @@ export function getCachedCostTracker(id: string): CostTrackingData | null {
     return cachedInMemory;
   }
 
-  if (!canUseSessionStorage()) {
-    return null;
-  }
-
-  try {
-    const serialized = window.sessionStorage.getItem(`${STORAGE_KEY_PREFIX}${cacheKey}`);
-    if (!serialized) {
-      return null;
-    }
-
-    const parsed = JSON.parse(serialized) as CostTrackingData;
-    memoryCache.set(cacheKey, parsed);
-    return parsed;
-  } catch (error) {
-    console.warn('Failed to read cached cost tracker data:', error);
-    return null;
-  }
+  clearPersistedCostTracker(cacheKey);
+  return null;
 }
 
 export function hasCachedCostTracker(id: string): boolean {
@@ -62,19 +47,7 @@ export function setCachedCostTracker(costData: CostTrackingData): void {
   };
 
   memoryCache.set(cacheKey, normalizedCostData);
-
-  if (!canUseSessionStorage()) {
-    return;
-  }
-
-  try {
-    window.sessionStorage.setItem(
-      `${STORAGE_KEY_PREFIX}${cacheKey}`,
-      JSON.stringify(normalizedCostData)
-    );
-  } catch (error) {
-    console.warn('Failed to persist cached cost tracker data:', error);
-  }
+  clearPersistedCostTracker(cacheKey);
 }
 
 export function clearCachedCostTracker(id: string): void {
@@ -90,6 +63,18 @@ export function clearCachedCostTracker(id: string): void {
     window.sessionStorage.removeItem(`${STORAGE_KEY_PREFIX}${cacheKey}`);
   } catch (error) {
     console.warn('Failed to clear cached cost tracker data:', error);
+  }
+}
+
+function clearPersistedCostTracker(cacheKey: string): void {
+  if (!canUseSessionStorage()) {
+    return;
+  }
+
+  try {
+    window.sessionStorage.removeItem(`${STORAGE_KEY_PREFIX}${cacheKey}`);
+  } catch (error) {
+    console.warn('Failed to clear persisted cost tracker cache:', error);
   }
 }
 

--- a/src/app/lib/costTrackerCache.ts
+++ b/src/app/lib/costTrackerCache.ts
@@ -54,16 +54,7 @@ export function clearCachedCostTracker(id: string): void {
   const cacheKey = getCacheKey(id);
   memoryCache.delete(cacheKey);
   inFlightRequests.delete(cacheKey);
-
-  if (!canUseSessionStorage()) {
-    return;
-  }
-
-  try {
-    window.sessionStorage.removeItem(`${STORAGE_KEY_PREFIX}${cacheKey}`);
-  } catch (error) {
-    console.warn('Failed to clear cached cost tracker data:', error);
-  }
+  clearPersistedCostTracker(cacheKey);
 }
 
 function clearPersistedCostTracker(cacheKey: string): void {

--- a/src/app/lib/offlineDeltaSync.ts
+++ b/src/app/lib/offlineDeltaSync.ts
@@ -2,7 +2,6 @@ import {
   createCostDataDelta,
   isCostDataDelta,
   isCostDataDeltaEmpty,
-  snapshotCostData,
   type CostDataDelta
 } from '@/app/lib/costDataDelta';
 import { cloneSerializable, isRecord } from '@/app/lib/collectionDelta';
@@ -540,9 +539,9 @@ export const queueCostDelta = ({ id, baseSnapshot, pendingSnapshot }: QueueCostD
   const now = new Date().toISOString();
 
   const canonicalBase = existingIndex >= 0 && queue[existingIndex].kind === 'cost'
-    ? redactCostSnapshotForBrowserStorage(snapshotCostData(queue[existingIndex].baseSnapshot))
-    : redactCostSnapshotForBrowserStorage(snapshotCostData(baseSnapshot));
-  const canonicalPending = redactCostSnapshotForBrowserStorage(snapshotCostData(pendingSnapshot));
+    ? redactCostSnapshotForBrowserStorage(queue[existingIndex].baseSnapshot)
+    : redactCostSnapshotForBrowserStorage(baseSnapshot);
+  const canonicalPending = redactCostSnapshotForBrowserStorage(pendingSnapshot);
   const mergedDelta = createCostDataDelta(canonicalBase, canonicalPending);
 
   if (!mergedDelta || isCostDataDeltaEmpty(mergedDelta)) {
@@ -629,7 +628,8 @@ const syncCostEntry = async (
     patchUrl: `/api/cost-tracking?id=${encodeURIComponent(entry.id)}`,
     baseSnapshot: entry.baseSnapshot,
     pendingDelta: entry.delta,
-    toComparable: toCostDeltaComparable,
+    toComparable: (candidate, fallback) =>
+      redactCostSnapshotForBrowserStorage(toCostDeltaComparable(candidate, fallback)),
     createDelta: createCostDataDelta,
     isDeltaEmpty: isCostDataDeltaEmpty
   });

--- a/src/app/lib/offlineDeltaSync.ts
+++ b/src/app/lib/offlineDeltaSync.ts
@@ -234,6 +234,46 @@ const isQuotaExceededError = (error: unknown): boolean => {
   return error.name === 'QuotaExceededError' || error.name === 'NS_ERROR_DOM_QUOTA_REACHED';
 };
 
+const redactYnabConfigForBrowserStorage = (
+  config: CostTrackingData['ynabConfig']
+): CostTrackingData['ynabConfig'] => {
+  if (!config) {
+    return undefined;
+  }
+
+  const safeConfig = { ...config };
+  const hasApiKey = Boolean(safeConfig.apiKey || safeConfig.hasApiKey);
+  delete safeConfig.apiKey;
+
+  return {
+    ...safeConfig,
+    ...(hasApiKey ? { hasApiKey: true } : {})
+  };
+};
+
+const redactCostSnapshotForBrowserStorage = (data: CostTrackingData): CostTrackingData => ({
+  ...cloneSerializable(data),
+  ynabConfig: redactYnabConfigForBrowserStorage(data.ynabConfig)
+});
+
+const redactCostDeltaForBrowserStorage = (delta: CostDataDelta): CostDataDelta => {
+  const safeDelta = cloneSerializable(delta);
+  if (Object.prototype.hasOwnProperty.call(safeDelta, 'ynabConfig')) {
+    safeDelta.ynabConfig = redactYnabConfigForBrowserStorage(safeDelta.ynabConfig);
+  }
+  return safeDelta;
+};
+
+const redactCostEntryForBrowserStorage = (entry: OfflineCostQueueEntry): OfflineCostQueueEntry => ({
+  ...entry,
+  baseSnapshot: redactCostSnapshotForBrowserStorage(entry.baseSnapshot),
+  pendingSnapshot: redactCostSnapshotForBrowserStorage(entry.pendingSnapshot),
+  delta: redactCostDeltaForBrowserStorage(entry.delta),
+  lastServerDelta: entry.lastServerDelta
+    ? redactCostDeltaForBrowserStorage(entry.lastServerDelta)
+    : undefined
+});
+
 const summarizeQueue = (entries: OfflineQueueEntry[]): OfflineQueueSummary => {
   const pending = entries.filter((entry) => entry.status === 'pending').length;
   const conflicts = entries.filter((entry) => entry.status === 'conflict').length;
@@ -298,7 +338,13 @@ const parseStoredEntries = (raw: unknown): OfflineQueueEntry[] => {
       return isTravelDataDelta(entry.delta);
     }
 
-    return isCostDataDelta(entry.delta);
+    if (!isCostDataDelta(entry.delta)) {
+      return false;
+    }
+
+    const safeCostEntry = redactCostEntryForBrowserStorage(entry as OfflineCostQueueEntry);
+    Object.assign(entry, safeCostEntry);
+    return true;
   });
 };
 
@@ -494,9 +540,9 @@ export const queueCostDelta = ({ id, baseSnapshot, pendingSnapshot }: QueueCostD
   const now = new Date().toISOString();
 
   const canonicalBase = existingIndex >= 0 && queue[existingIndex].kind === 'cost'
-    ? snapshotCostData(queue[existingIndex].baseSnapshot)
-    : snapshotCostData(baseSnapshot);
-  const canonicalPending = snapshotCostData(pendingSnapshot);
+    ? redactCostSnapshotForBrowserStorage(snapshotCostData(queue[existingIndex].baseSnapshot))
+    : redactCostSnapshotForBrowserStorage(snapshotCostData(baseSnapshot));
+  const canonicalPending = redactCostSnapshotForBrowserStorage(snapshotCostData(pendingSnapshot));
   const mergedDelta = createCostDataDelta(canonicalBase, canonicalPending);
 
   if (!mergedDelta || isCostDataDeltaEmpty(mergedDelta)) {
@@ -512,7 +558,7 @@ export const queueCostDelta = ({ id, baseSnapshot, pendingSnapshot }: QueueCostD
     id: normalizedId,
     baseSnapshot: canonicalBase,
     pendingSnapshot: canonicalPending,
-    delta: mergedDelta,
+    delta: redactCostDeltaForBrowserStorage(mergedDelta),
     queuedAt: existingIndex >= 0 ? queue[existingIndex].queuedAt : now,
     updatedAt: now,
     status: 'pending'

--- a/src/app/lib/travelDataCache.ts
+++ b/src/app/lib/travelDataCache.ts
@@ -37,16 +37,7 @@ export function setCachedTravelData(travelData: TravelData): void {
 export function clearCachedTravelData(id: string): void {
   memoryCache.delete(id);
   inFlightRequests.delete(id);
-
-  if (!canUseSessionStorage()) {
-    return;
-  }
-
-  try {
-    window.sessionStorage.removeItem(`${STORAGE_KEY_PREFIX}${id}`);
-  } catch (error) {
-    console.warn('Failed to clear cached travel data:', error);
-  }
+  clearPersistedTravelData(id);
 }
 
 function clearPersistedTravelData(id: string): void {

--- a/src/app/lib/travelDataCache.ts
+++ b/src/app/lib/travelDataCache.ts
@@ -17,23 +17,8 @@ export function getCachedTravelData(id: string): TravelData | null {
     return cachedInMemory;
   }
 
-  if (!canUseSessionStorage()) {
-    return null;
-  }
-
-  try {
-    const serialized = window.sessionStorage.getItem(`${STORAGE_KEY_PREFIX}${id}`);
-    if (!serialized) {
-      return null;
-    }
-
-    const parsed = JSON.parse(serialized) as TravelData;
-    memoryCache.set(id, parsed);
-    return parsed;
-  } catch (error) {
-    console.warn('Failed to read cached travel data:', error);
-    return null;
-  }
+  clearPersistedTravelData(id);
+  return null;
 }
 
 export function hasCachedTravelData(id: string): boolean {
@@ -46,19 +31,7 @@ export function setCachedTravelData(travelData: TravelData): void {
   }
 
   memoryCache.set(travelData.id, travelData);
-
-  if (!canUseSessionStorage()) {
-    return;
-  }
-
-  try {
-    window.sessionStorage.setItem(
-      `${STORAGE_KEY_PREFIX}${travelData.id}`,
-      JSON.stringify(travelData)
-    );
-  } catch (error) {
-    console.warn('Failed to persist cached travel data:', error);
-  }
+  clearPersistedTravelData(travelData.id);
 }
 
 export function clearCachedTravelData(id: string): void {
@@ -73,6 +46,18 @@ export function clearCachedTravelData(id: string): void {
     window.sessionStorage.removeItem(`${STORAGE_KEY_PREFIX}${id}`);
   } catch (error) {
     console.warn('Failed to clear cached travel data:', error);
+  }
+}
+
+function clearPersistedTravelData(id: string): void {
+  if (!canUseSessionStorage()) {
+    return;
+  }
+
+  try {
+    window.sessionStorage.removeItem(`${STORAGE_KEY_PREFIX}${id}`);
+  } catch (error) {
+    console.warn('Failed to clear persisted travel data cache:', error);
   }
 }
 


### PR DESCRIPTION
## Summary
- make full trip and cost tracker caches memory-only while clearing legacy sessionStorage entries
- redact YNAB API keys before cost offline queue entries are serialized to localStorage
- add regression tests for sessionStorage clearing and offline queue redaction

## Security findings covered
- f5a6c63487208191bc430943c31435fd
- 62ab23044b6c819193ae48f48e96d860
- 6fce33b7bd28819181b33c02db4f3f82
- 890947fb0a908191a75388e2e440a647
- 5ed053dc616c81919116e5cf75474277

## Verification
- bun run test:unit -- src/app/__tests__/lib/travelDataCache.test.ts src/app/__tests__/lib/costTrackerCache.test.ts src/app/__tests__/lib/offlineDeltaSync.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint src/app/lib/travelDataCache.ts src/app/lib/costTrackerCache.ts src/app/lib/offlineDeltaSync.ts src/app/__tests__/lib/travelDataCache.test.ts src/app/__tests__/lib/costTrackerCache.test.ts src/app/__tests__/lib/offlineDeltaSync.test.ts --max-warnings=0
- bun run build