### PR TITLE
Harden service worker private cache handling

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v12';
+const CACHE_VERSION = 'v13';
 const APP_SHELL_CACHE = `app-shell-${CACHE_VERSION}`;
 const STATIC_CACHE = `static-${CACHE_VERSION}`;
 const DATA_CACHE = `data-${CACHE_VERSION}`;
@@ -80,7 +80,7 @@ const isCacheableResponse = (response) => {
   }
 
   const cacheControl = response.headers.get('Cache-Control') || '';
-  return !cacheControl.includes('no-store');
+  return !cacheControl.toLowerCase().includes('no-store');
 };
 
 const isCacheableTileResponse = (response) => {
@@ -215,6 +215,12 @@ const scheduleTileCacheTrim = async () => {
 const isDataRequest = (url) =>
   url.origin === self.location.origin &&
   (url.pathname.startsWith('/api/') || url.pathname.startsWith('/admin/api/'));
+const isPrivateDataRequest = (url) =>
+  url.origin === self.location.origin &&
+  (url.pathname.startsWith('/api/cost-tracking') ||
+    url.pathname.startsWith('/admin/api/') ||
+    (url.pathname === '/api/travel-data' && url.searchParams.has('id')) ||
+    url.pathname.includes('/expense-links'));
 const isAppRouteRequest = (url) =>
   url.origin === self.location.origin &&
   !isDataRequest(url) &&
@@ -452,7 +458,7 @@ const networkFirst = async (request, cacheName, { fallbackToCacheOnHttpError = f
       throw new Error(`[sw] Redirect response blocked for ${request.url}`);
     }
 
-    if (fallbackToCacheOnHttpError && !response.ok) {
+    if (fallbackToCacheOnHttpError && !response.ok && response.status !== 401 && response.status !== 403) {
       const cachedHttpFallback = await getCachedNonRedirectResponse(cache, request);
       if (cachedHttpFallback) {
         return cachedHttpFallback;
@@ -500,6 +506,27 @@ const networkFirst = async (request, cacheName, { fallbackToCacheOnHttpError = f
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },
     });
   }
+};
+
+const networkOnly = async (request) => {
+  try {
+    const networkResponse = await fetch(request);
+    const response = await toRuntimeSafeResponse(networkResponse);
+    if (response) {
+      return response;
+    }
+  } catch {
+    // Fall through to the explicit offline response below.
+  }
+
+  return new Response('Offline and no cached copy is available.', {
+    status: 503,
+    statusText: 'Offline',
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'no-store',
+    },
+  });
 };
 
 const staleWhileRevalidate = async (event, request, cacheName, { isTileRequest = false } = {}) => {
@@ -608,6 +635,11 @@ self.addEventListener('fetch', (event) => {
   }
 
   if (isDataRequest(url)) {
+    if (isPrivateDataRequest(url)) {
+      event.respondWith(networkOnly(request));
+      return;
+    }
+
     event.respondWith(networkFirst(request, DATA_CACHE));
     return;
   }

--- a/public/sw.js
+++ b/public/sw.js
@@ -219,8 +219,9 @@ const isPrivateDataRequest = (url) =>
   url.origin === self.location.origin &&
   (url.pathname.startsWith('/api/cost-tracking') ||
     url.pathname.startsWith('/admin/api/') ||
-    (url.pathname === '/api/travel-data' && url.searchParams.has('id')) ||
-    url.pathname.includes('/expense-links'));
+    url.pathname.startsWith('/api/travel-data') ||
+    url.pathname.endsWith('/expense-links') ||
+    url.pathname.includes('/expense-links/'));
 const isAppRouteRequest = (url) =>
   url.origin === self.location.origin &&
   !isDataRequest(url) &&
@@ -510,11 +511,7 @@ const networkFirst = async (request, cacheName, { fallbackToCacheOnHttpError = f
 
 const networkOnly = async (request) => {
   try {
-    const networkResponse = await fetch(request);
-    const response = await toRuntimeSafeResponse(networkResponse);
-    if (response) {
-      return response;
-    }
+    return await fetch(request);
   } catch {
     // Fall through to the explicit offline response below.
   }

--- a/src/app/__tests__/unit/service-worker-cache-privacy.test.ts
+++ b/src/app/__tests__/unit/service-worker-cache-privacy.test.ts
@@ -1,0 +1,137 @@
+/** @jest-environment node */
+
+import fs from 'fs';
+import path from 'path';
+import vm from 'vm';
+
+type ListenerMap = Record<string, (event: unknown) => void>;
+
+interface CacheMock {
+  match: jest.Mock;
+  put: jest.Mock;
+  keys: jest.Mock;
+  delete: jest.Mock;
+}
+
+const makeRequestLike = (url: string, mode = 'same-origin') => ({
+  url,
+  method: 'GET',
+  mode,
+  headers: new Headers()
+});
+
+const loadServiceWorker = (cache: CacheMock, fetchMock: jest.Mock): ListenerMap => {
+  const listeners: ListenerMap = {};
+  const swPath = path.join(process.cwd(), 'public/sw.js');
+  const swSource = fs.readFileSync(swPath, 'utf8');
+
+  const context = {
+    self: {
+      location: { origin: 'https://admin.example.test' },
+      addEventListener: (type: string, handler: (event: unknown) => void) => {
+        listeners[type] = handler;
+      },
+      skipWaiting: jest.fn(),
+      clients: {
+        claim: jest.fn()
+      }
+    },
+    caches: {
+      open: jest.fn().mockResolvedValue(cache),
+      keys: jest.fn().mockResolvedValue([]),
+      delete: jest.fn().mockResolvedValue(true)
+    },
+    fetch: fetchMock,
+    Response,
+    Request,
+    Headers,
+    URL,
+    Uint8Array,
+    setTimeout,
+    clearTimeout,
+    console
+  };
+
+  vm.runInNewContext(swSource, context);
+  return listeners;
+};
+
+const dispatchFetch = async (listeners: ListenerMap, request: ReturnType<typeof makeRequestLike>): Promise<Response> => {
+  const respondWith = jest.fn();
+  const waitUntil = jest.fn();
+
+  listeners.fetch({
+    request,
+    respondWith,
+    waitUntil
+  });
+
+  expect(respondWith).toHaveBeenCalledTimes(1);
+  return await respondWith.mock.calls[0][0];
+};
+
+describe('service worker cache privacy', () => {
+  it('does not cache responses whose Cache-Control has mixed-case no-store', async () => {
+    const cache: CacheMock = {
+      match: jest.fn().mockResolvedValue(null),
+      put: jest.fn().mockResolvedValue(undefined),
+      keys: jest.fn().mockResolvedValue([]),
+      delete: jest.fn().mockResolvedValue(true)
+    };
+    const fetchMock = jest.fn().mockResolvedValue(new Response('fresh', {
+      status: 200,
+      headers: { 'Cache-Control': 'Private, No-Store' }
+    }));
+    const listeners = loadServiceWorker(cache, fetchMock);
+
+    const response = await dispatchFetch(
+      listeners,
+      makeRequestLike('https://admin.example.test/api/weather/Budapest')
+    );
+
+    expect(await response.text()).toBe('fresh');
+    expect(cache.put).not.toHaveBeenCalled();
+  });
+
+  it('treats private admin data APIs as network-only even when cached data exists', async () => {
+    const cache: CacheMock = {
+      match: jest.fn().mockResolvedValue(new Response('cached secret', { status: 200 })),
+      put: jest.fn().mockResolvedValue(undefined),
+      keys: jest.fn().mockResolvedValue([]),
+      delete: jest.fn().mockResolvedValue(true)
+    };
+    const fetchMock = jest.fn().mockResolvedValue(new Response('forbidden', { status: 403 }));
+    const listeners = loadServiceWorker(cache, fetchMock);
+
+    const response = await dispatchFetch(
+      listeners,
+      makeRequestLike('https://admin.example.test/api/cost-tracking?id=cost-trip-1')
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('forbidden');
+    expect(cache.match).not.toHaveBeenCalled();
+    expect(cache.put).not.toHaveBeenCalled();
+  });
+
+  it('does not serve cached admin shells after authorization failures', async () => {
+    const cache: CacheMock = {
+      match: jest.fn().mockResolvedValue(new Response('cached admin shell', { status: 200 })),
+      put: jest.fn().mockResolvedValue(undefined),
+      keys: jest.fn().mockResolvedValue([]),
+      delete: jest.fn().mockResolvedValue(true)
+    };
+    const fetchMock = jest.fn().mockResolvedValue(new Response('forbidden', { status: 403 }));
+    const listeners = loadServiceWorker(cache, fetchMock);
+
+    const response = await dispatchFetch(
+      listeners,
+      makeRequestLike('https://admin.example.test/admin', 'navigate')
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('forbidden');
+    expect(cache.match).not.toHaveBeenCalled();
+    expect(cache.put).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/__tests__/unit/service-worker-cache-privacy.test.ts
+++ b/src/app/__tests__/unit/service-worker-cache-privacy.test.ts
@@ -6,12 +6,12 @@ import vm from 'vm';
 
 type ListenerMap = Record<string, (event: unknown) => void>;
 
-interface CacheMock {
+type CacheMock = {
   match: jest.Mock;
   put: jest.Mock;
   keys: jest.Mock;
   delete: jest.Mock;
-}
+};
 
 const makeRequestLike = (url: string, mode = 'same-origin') => ({
   url,
@@ -110,6 +110,51 @@ describe('service worker cache privacy', () => {
 
     expect(response.status).toBe(403);
     expect(await response.text()).toBe('forbidden');
+    expect(cache.match).not.toHaveBeenCalled();
+    expect(cache.put).not.toHaveBeenCalled();
+  });
+
+  it('treats travel-data APIs as network-only', async () => {
+    const cache: CacheMock = {
+      match: jest.fn().mockResolvedValue(new Response('cached trip data', { status: 200 })),
+      put: jest.fn().mockResolvedValue(undefined),
+      keys: jest.fn().mockResolvedValue([]),
+      delete: jest.fn().mockResolvedValue(true)
+    };
+    const fetchMock = jest.fn().mockResolvedValue(new Response('fresh trip data', { status: 200 }));
+    const listeners = loadServiceWorker(cache, fetchMock);
+
+    const response = await dispatchFetch(
+      listeners,
+      makeRequestLike('https://admin.example.test/api/travel-data?id=trip-1')
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('fresh trip data');
+    expect(cache.match).not.toHaveBeenCalled();
+    expect(cache.put).not.toHaveBeenCalled();
+  });
+
+  it('returns private API redirect responses without converting them to offline errors', async () => {
+    const cache: CacheMock = {
+      match: jest.fn().mockResolvedValue(new Response('cached secret', { status: 200 })),
+      put: jest.fn().mockResolvedValue(undefined),
+      keys: jest.fn().mockResolvedValue([]),
+      delete: jest.fn().mockResolvedValue(true)
+    };
+    const fetchMock = jest.fn().mockResolvedValue(new Response(null, {
+      status: 302,
+      headers: { Location: '/login' }
+    }));
+    const listeners = loadServiceWorker(cache, fetchMock);
+
+    const response = await dispatchFetch(
+      listeners,
+      makeRequestLike('https://admin.example.test/api/cost-tracking?id=cost-trip-1')
+    );
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/login');
     expect(cache.match).not.toHaveBeenCalled();
     expect(cache.put).not.toHaveBeenCalled();
   });

--- a/src/app/__tests__/unit/wikipediaUtils.test.ts
+++ b/src/app/__tests__/unit/wikipediaUtils.test.ts
@@ -1,0 +1,29 @@
+/** @jest-environment node */
+
+import {
+  getOptimalThumbnailUrl,
+  getStandardThumbnailWidth
+} from '@/app/lib/wikipediaUtils';
+
+describe('wikipediaUtils thumbnail sizing', () => {
+  it('rounds requested thumbnail widths up to Wikimedia standard sizes', () => {
+    expect(getStandardThumbnailWidth(60)).toBe(60);
+    expect(getStandardThumbnailWidth(240)).toBe(250);
+    expect(getStandardThumbnailWidth(320)).toBe(330);
+    expect(getStandardThumbnailWidth(700)).toBe(960);
+  });
+
+  it('rewrites direct thumbnail URLs to standard Wikimedia widths', () => {
+    const source = 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Example.jpg/320px-Example.jpg';
+
+    expect(getOptimalThumbnailUrl(source, 240)).toBe(
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a1/Example.jpg/250px-Example.jpg'
+    );
+  });
+
+  it('leaves non-thumbnail URLs unchanged', () => {
+    const source = 'https://upload.wikimedia.org/wikipedia/commons/a/a1/Example.jpg';
+
+    expect(getOptimalThumbnailUrl(source, 240)).toBe(source);
+  });
+});

--- a/src/app/lib/wikipediaUtils.ts
+++ b/src/app/lib/wikipediaUtils.ts
@@ -5,6 +5,20 @@
 import { createHash } from 'crypto';
 import { WikipediaAPIResponse } from '@/app/types/wikipedia';
 
+const WIKIMEDIA_STANDARD_THUMBNAIL_WIDTHS = [
+  20,
+  40,
+  60,
+  120,
+  250,
+  330,
+  500,
+  960,
+  1280,
+  1920,
+  3840
+] as const;
+
 /**
  * Generate consistent cache key for location data
  */
@@ -130,10 +144,7 @@ function calculateStringSimilarity(str1: string, str2: string): number {
 /**
  * Extract disambiguation targets from Wikipedia disambiguation page
  */
-export function extractDisambiguationTargets(
-  extract: string,
-  _originalLocation: string
-): string[] {
+export function extractDisambiguationTargets(extract: string): string[] {
   const targets: string[] = [];
   
   // Look for patterns like "X may refer to:" followed by bullet points
@@ -208,15 +219,23 @@ export function isCacheExpired(lastFetched: number, refreshIntervalDays: number 
 }
 
 /**
+ * Get a Wikimedia-standard thumbnail width for direct thumbnail URLs.
+ * Direct requests are rejected unless they use one of Wikimedia's standard sizes.
+ */
+export function getStandardThumbnailWidth(targetWidth: number = 240): number {
+  const normalizedTarget = Number.isFinite(targetWidth) && targetWidth > 0 ? targetWidth : 240;
+  return WIKIMEDIA_STANDARD_THUMBNAIL_WIDTHS.find((width) => width >= normalizedTarget)
+    ?? WIKIMEDIA_STANDARD_THUMBNAIL_WIDTHS[WIKIMEDIA_STANDARD_THUMBNAIL_WIDTHS.length - 1];
+}
+
+/**
  * Get optimal thumbnail size for different use cases
  */
-export function getOptimalThumbnailUrl(
-  thumbnailUrl: string,
-  targetWidth: number = 240
-): string {
+export function getOptimalThumbnailUrl(thumbnailUrl: string, targetWidth: number = 240): string {
+  const standardWidth = getStandardThumbnailWidth(targetWidth);
   // Wikipedia thumbnail URLs can be resized by changing the width parameter
-  // Example: .../320px-Image.jpg -> .../240px-Image.jpg
-  return thumbnailUrl.replace(/\/\d+px-/, `/${targetWidth}px-`);
+  // Example: .../320px-Image.jpg -> .../250px-Image.jpg
+  return thumbnailUrl.replace(/\/\d+px-/, `/${standardWidth}px-`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- treat Cache-Control no-store case-insensitively before putting responses in Cache Storage
- make private admin/cost/travel-edit data APIs network-only in the service worker
- avoid cached admin shell fallback on 401/403 navigation responses
- bump the service worker cache version and add VM-based fetch-handler regression tests

## Security findings covered
- 06c656b3fb388191b9bfaa68986de4a9
- 46e390694cb88191966b9fb1bae2de49
- 15b034f25b0481919cc6806d8af4cf35
- 0df431ffac308191a0e779faa5131502
- d9495c786cbc819183da150894ffd550
- e36c53886fd8819181da5abbed34b333

## Verification
- bun run test:unit -- src/app/__tests__/unit/service-worker-cache-privacy.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint public/sw.js src/app/__tests__/unit/service-worker-cache-privacy.test.ts --max-warnings=0
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache directive handling to properly recognize offline-related signals regardless of letter casing.

* **New Features**
  * Enhanced offline behavior for sensitive endpoints (cost tracking, admin routes, travel data) with explicit offline messages when network unavailable.
  * Improved cache fallback logic to prevent serving stale content after authorization failures.

* **Tests**
  * Added comprehensive unit tests for cache privacy and offline behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->