### PR TITLE
Keep cost tracking GET read-only

### DIFF
--- a/src/app/__tests__/api/ynab-token-boundary.test.ts
+++ b/src/app/__tests__/api/ynab-token-boundary.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@/app/api/ynab/transactions/route';
 import { loadUnifiedTripData, listAllTrips } from '@/app/lib/unifiedDataService';
 import { YnabApiClient } from '@/app/lib/ynabApiClient';
+import { maybeSyncPendingYnabTransactions } from '@/app/lib/ynabPendingSync';
 
 const mockGetCategories = jest.fn();
 
@@ -53,6 +54,7 @@ const { isAdminDomain: mockIsAdminDomain } = jest.requireMock('@/app/lib/server-
 const mockLoadUnifiedTripData = loadUnifiedTripData as jest.MockedFunction<typeof loadUnifiedTripData>;
 const mockListAllTrips = listAllTrips as jest.MockedFunction<typeof listAllTrips>;
 const mockYnabApiClient = YnabApiClient as jest.MockedClass<typeof YnabApiClient>;
+const mockMaybeSyncPendingYnabTransactions = maybeSyncPendingYnabTransactions as jest.MockedFunction<typeof maybeSyncPendingYnabTransactions>;
 
 const buildTrip = () => ({
   schemaVersion: 9,
@@ -107,6 +109,37 @@ describe('YNAB token boundary', () => {
     });
     expect(result.ynabConfig.apiKey).toBeUndefined();
     expect(serialized).not.toContain('SECRET-YNAB-TOKEN');
+  });
+
+  it('keeps cost-tracking GET read-only even when stored YNAB sync metadata exists', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+    mockLoadUnifiedTripData.mockResolvedValue({
+      ...buildTrip(),
+      costData: {
+        ...buildTrip().costData,
+        ynabConfig: {
+          ...buildTrip().costData.ynabConfig,
+          lastTransactionImport: new Date('2026-05-01T00:00:00.000Z'),
+          lastAutomaticTransactionSync: new Date('2026-05-01T01:00:00.000Z'),
+          automaticTransactionServerKnowledge: 10,
+        },
+        ynabImportData: {
+          mappings: [
+            {
+              ynabCategoryId: 'cat-1',
+              mappingType: 'general',
+            },
+          ],
+        },
+      },
+    });
+
+    const response = await costTrackingGET(
+      new NextRequest('https://admin.example.test/api/cost-tracking?id=trip-1')
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockMaybeSyncPendingYnabTransactions).not.toHaveBeenCalled();
   });
 
   it('redacts stored YNAB tokens from cost-tracking list data', async () => {

--- a/src/app/__tests__/api/ynab-token-boundary.test.ts
+++ b/src/app/__tests__/api/ynab-token-boundary.test.ts
@@ -12,6 +12,7 @@ import {
   POST as ynabTransactionsPOST,
 } from '@/app/api/ynab/transactions/route';
 import { loadUnifiedTripData, listAllTrips } from '@/app/lib/unifiedDataService';
+import { parseDateAsLocalDay } from '@/app/lib/localDateUtils';
 import { YnabApiClient } from '@/app/lib/ynabApiClient';
 import { maybeSyncPendingYnabTransactions } from '@/app/lib/ynabPendingSync';
 
@@ -55,6 +56,7 @@ const mockLoadUnifiedTripData = loadUnifiedTripData as jest.MockedFunction<typeo
 const mockListAllTrips = listAllTrips as jest.MockedFunction<typeof listAllTrips>;
 const mockYnabApiClient = YnabApiClient as jest.MockedClass<typeof YnabApiClient>;
 const mockMaybeSyncPendingYnabTransactions = maybeSyncPendingYnabTransactions as jest.MockedFunction<typeof maybeSyncPendingYnabTransactions>;
+const syncBaselineDate = parseDateAsLocalDay('2026-05-01')!;
 
 const buildTrip = () => ({
   schemaVersion: 9,
@@ -119,8 +121,8 @@ describe('YNAB token boundary', () => {
         ...buildTrip().costData,
         ynabConfig: {
           ...buildTrip().costData.ynabConfig,
-          lastTransactionImport: new Date('2026-05-01T00:00:00.000Z'),
-          lastAutomaticTransactionSync: new Date('2026-05-01T01:00:00.000Z'),
+          lastTransactionImport: syncBaselineDate,
+          lastAutomaticTransactionSync: syncBaselineDate,
           automaticTransactionServerKnowledge: 10,
         },
         ynabImportData: {

--- a/src/app/api/cost-tracking/route.ts
+++ b/src/app/api/cost-tracking/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { updateCostData, loadUnifiedTripData, deleteCostTrackingWithBackup } from '@/app/lib/unifiedDataService';
-import { maybeSyncPendingYnabTransactions } from '@/app/lib/ynabPendingSync';
 import { isAdminDomain } from '@/app/lib/server-domains';
 import { validateAllTripBoundaries } from '@/app/lib/tripBoundaryValidation';
 import { dateReviver } from '@/app/lib/jsonDateReviver';
@@ -78,12 +77,7 @@ export async function GET(request: NextRequest) {
     
     // Load unified trip data
     const unifiedData = await loadUnifiedTripData(cleanId);
-    const syncedData = unifiedData
-      ? await maybeSyncPendingYnabTransactions(cleanId, unifiedData)
-      : null;
-    const costDataSource = syncedData || unifiedData;
-
-    if (!costDataSource?.costData) {
+    if (!unifiedData?.costData) {
       return NextResponse.json(
         { error: 'Cost tracking data not found' },
         { status: 404 }
@@ -91,7 +85,7 @@ export async function GET(request: NextRequest) {
     }
     
     // Validate trip boundaries
-    const validation = validateAllTripBoundaries(costDataSource);
+    const validation = validateAllTripBoundaries(unifiedData);
     if (!validation.isValid) {
       console.warn('Trip boundary violations detected in trip %s:', cleanId, validation.errors);
       // Continue processing but log the violations
@@ -102,19 +96,19 @@ export async function GET(request: NextRequest) {
     const costData = {
       id: `cost-${cleanId}`,
       tripId: cleanId,
-      tripTitle: costDataSource.title,
-      tripStartDate: costDataSource.startDate,
-      tripEndDate: costDataSource.endDate,
-      overallBudget: costDataSource.costData.overallBudget,
-      reservedBudget: costDataSource.costData.reservedBudget || 0,
-      currency: costDataSource.costData.currency,
-      customCategories: costDataSource.costData.customCategories,
-      countryBudgets: costDataSource.costData.countryBudgets,
-      expenses: costDataSource.costData.expenses, // These are already trip-scoped by design
-      ynabImportData: costDataSource.costData.ynabImportData,
-      ynabConfig: redactYnabConfig(costDataSource.costData.ynabConfig),
-      createdAt: costDataSource.createdAt,
-      updatedAt: costDataSource.updatedAt,
+      tripTitle: unifiedData.title,
+      tripStartDate: unifiedData.startDate,
+      tripEndDate: unifiedData.endDate,
+      overallBudget: unifiedData.costData.overallBudget,
+      reservedBudget: unifiedData.costData.reservedBudget || 0,
+      currency: unifiedData.costData.currency,
+      customCategories: unifiedData.costData.customCategories,
+      countryBudgets: unifiedData.costData.countryBudgets,
+      expenses: unifiedData.costData.expenses, // These are already trip-scoped by design
+      ynabImportData: unifiedData.costData.ynabImportData,
+      ynabConfig: redactYnabConfig(unifiedData.costData.ynabConfig),
+      createdAt: unifiedData.createdAt,
+      updatedAt: unifiedData.updatedAt,
       // Add validation status for monitoring
       hasValidationWarnings: !validation.isValid
     };


### PR DESCRIPTION
## Summary
- remove the automatic pending YNAB sync mutation from GET /api/cost-tracking
- keep cost-tracking reads on the loaded unified trip data and continue redacting YNAB config in responses
- add a regression test that stored YNAB sync metadata does not cause GET to invoke the mutating sync helper

## Verification
- bun run test:unit -- src/app/__tests__/api/ynab-token-boundary.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint src/app/api/cost-tracking/route.ts src/app/__tests__/api/ynab-token-boundary.test.ts --max-warnings=0

Security finding: 117a07f0443481918bc6cc9a5cfaf9ef