### PR TITLE
Harden local deploy helper scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Multi-stage build for production
-FROM oven/bun:alpine AS base
+ARG BUN_IMAGE=oven/bun:1.3.4-alpine
+FROM ${BUN_IMAGE} AS base
 
 # Install dependencies only when needed
 FROM base AS deps
@@ -28,7 +29,7 @@ RUN --mount=type=cache,target=/app/.next/cache \
     bun run build
 
 # Production image - optimized Alpine
-FROM oven/bun:alpine AS runner
+FROM ${BUN_IMAGE} AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -38,8 +38,9 @@ PI_HOST=${PI_HOST:-}
 PI_USER=${PI_USER:-pi}
 DEPLOY_PATH=${DEPLOY_PATH:-/home/${PI_USER}/travel-tracker}
 # SSH connection multiplexing - reuse a single authenticated connection
-SSH_CONTROL_ID=$(printf '%s' "${PI_USER}-${PI_HOST}" | tr -c 'A-Za-z0-9_.-' '_')
-SSH_CONTROL_PATH="/tmp/ssh-deploy-${SSH_CONTROL_ID}"
+SSH_CONTROL_DIR=$(mktemp -d "${TMPDIR:-/tmp}/travel-tracker-ssh.XXXXXX")
+chmod 700 "$SSH_CONTROL_DIR"
+SSH_CONTROL_PATH="${SSH_CONTROL_DIR}/control"
 SSH_OPTS=(
     -o ControlMaster=auto
     -o ControlPath="$SSH_CONTROL_PATH"
@@ -50,9 +51,10 @@ SSH_OPTS=(
 
 # Clean up SSH control socket on exit
 cleanup_ssh() {
-    if [ -S "$SSH_CONTROL_PATH" ]; then
+    if [ -n "${PI_HOST:-}" ] && [ -S "$SSH_CONTROL_PATH" ]; then
         ssh -O exit -o ControlPath="$SSH_CONTROL_PATH" "$PI_USER@$PI_HOST" 2>/dev/null || true
     fi
+    rm -rf "$SSH_CONTROL_DIR"
 }
 trap cleanup_ssh EXIT
 
@@ -245,8 +247,9 @@ run_ssh "
 
 # Create local backup of remote data directory
 echo "💾 Creating local backup of remote data directory..."
-LOCAL_BACKUP_DIR=${LOCAL_BACKUP_DIR:-"$PWD/backups"}
+LOCAL_BACKUP_DIR=${LOCAL_BACKUP_DIR:-"${XDG_STATE_HOME:-$HOME/.local/state}/travel-tracker/backups"}
 mkdir -p "$LOCAL_BACKUP_DIR"
+chmod 700 "$LOCAL_BACKUP_DIR"
 BACKUP_TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
 LOCAL_BACKUP_FILE="$LOCAL_BACKUP_DIR/data-$BACKUP_TIMESTAMP.tar.gz"
 
@@ -267,7 +270,8 @@ if [ -z "$REMOTE_DATA_PATH" ]; then
 fi
 
 REMOTE_DATA_PATH_ESCAPED=$(printf '%q' "$REMOTE_DATA_PATH")
-if ssh "${SSH_OPTS[@]}" "$PI_USER@$PI_HOST" "tar -czf - -C $REMOTE_DATA_PATH_ESCAPED ." > "$LOCAL_BACKUP_FILE"; then
+if (umask 077 && ssh "${SSH_OPTS[@]}" "$PI_USER@$PI_HOST" "tar -czf - -C $REMOTE_DATA_PATH_ESCAPED ." > "$LOCAL_BACKUP_FILE"); then
+    chmod 600 "$LOCAL_BACKUP_FILE"
     echo "✅ Local backup saved to $LOCAL_BACKUP_FILE"
 else
     echo "❌ Failed to download remote backup."

--- a/deploy/restore.sh
+++ b/deploy/restore.sh
@@ -34,6 +34,7 @@ fi
 PI_HOST=${PI_HOST:-}
 PI_USER=${PI_USER:-pi}
 DEPLOY_PATH=${DEPLOY_PATH:-/home/${PI_USER}/travel-tracker}
+CONTAINER_DATA_GID=${CONTAINER_DATA_GID:-1001}
 KEYCHAIN_SERVICE="travel-tracker-deploy"
 KEYCHAIN_ACCOUNT="$PI_USER@$PI_HOST"
 BACKUPS_DIR=${BACKUPS_DIR:-"${XDG_STATE_HOME:-$HOME/.local/state}/travel-tracker/backups"}
@@ -246,9 +247,10 @@ run_ssh "rm -f \"$TEMP_REMOTE_FILE\""
 
 # Fix permissions after restore (users often have permission issues if files are restored as root)
 echo "🔧 Fixing permissions..."
-run_ssh "echo \"$PASSWORD\" | sudo -S chown -R $PI_USER:1001 \"$REMOTE_DATA_PATH\""
-run_ssh "echo \"$PASSWORD\" | sudo -S find \"$REMOTE_DATA_PATH\" -type d -exec chmod 770 {} +"
-run_ssh "echo \"$PASSWORD\" | sudo -S find \"$REMOTE_DATA_PATH\" -type f -exec chmod 660 {} +"
+OWNER_SPEC_ESCAPED=$(printf '%q' "$PI_USER:$CONTAINER_DATA_GID")
+run_ssh "echo \"$PASSWORD\" | sudo -S chown -R $OWNER_SPEC_ESCAPED $REMOTE_DATA_PATH_ESCAPED"
+run_ssh "echo \"$PASSWORD\" | sudo -S find $REMOTE_DATA_PATH_ESCAPED -type d -exec chmod 770 {} +"
+run_ssh "echo \"$PASSWORD\" | sudo -S find $REMOTE_DATA_PATH_ESCAPED -type f -exec chmod 660 {} +"
 
 
 echo "✅ Backup restored successfully."

--- a/deploy/restore.sh
+++ b/deploy/restore.sh
@@ -36,7 +36,7 @@ PI_USER=${PI_USER:-pi}
 DEPLOY_PATH=${DEPLOY_PATH:-/home/${PI_USER}/travel-tracker}
 KEYCHAIN_SERVICE="travel-tracker-deploy"
 KEYCHAIN_ACCOUNT="$PI_USER@$PI_HOST"
-BACKUPS_DIR="backups"
+BACKUPS_DIR=${BACKUPS_DIR:-"${XDG_STATE_HOME:-$HOME/.local/state}/travel-tracker/backups"}
 
 # Function to get password from keychain or prompt for it
 get_password() {
@@ -103,6 +103,9 @@ if [ -z "$PI_HOST" ]; then
 fi
 
 echo "🚀 Starting Travel Tracker Restore Process..."
+
+mkdir -p "$BACKUPS_DIR"
+chmod 700 "$BACKUPS_DIR"
 
 # Get password first
 get_password
@@ -202,7 +205,8 @@ echo "🛡️  Creating safety backup LOCALLY: $LOCAL_SAFETY_BACKUP"
 # Use specific tar logic to stream remote data to local file
 # Using sudo to ensure we can read all files (even root-owned ones)
 REMOTE_DATA_PATH_ESCAPED=$(printf '%q' "$REMOTE_DATA_PATH")
-if sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no $PI_USER@$PI_HOST "echo \"$PASSWORD\" | sudo -S tar -czf - -C $REMOTE_DATA_PATH_ESCAPED ." > "$LOCAL_SAFETY_BACKUP"; then
+if (umask 077 && sshpass -p "$PASSWORD" ssh -o StrictHostKeyChecking=no $PI_USER@$PI_HOST "echo \"$PASSWORD\" | sudo -S tar -czf - -C $REMOTE_DATA_PATH_ESCAPED ." > "$LOCAL_SAFETY_BACKUP"); then
+    chmod 600 "$LOCAL_SAFETY_BACKUP"
     echo "✅ Safety backup saved to $LOCAL_SAFETY_BACKUP"
 else
     echo "❌ Failed to download safety backup."
@@ -242,8 +246,9 @@ run_ssh "rm -f \"$TEMP_REMOTE_FILE\""
 
 # Fix permissions after restore (users often have permission issues if files are restored as root)
 echo "🔧 Fixing permissions..."
-run_ssh "echo \"$PASSWORD\" | sudo -S chown -R $PI_USER:$PI_USER \"$REMOTE_DATA_PATH\""
-run_ssh "echo \"$PASSWORD\" | sudo -S chmod -R 777 \"$REMOTE_DATA_PATH\""
+run_ssh "echo \"$PASSWORD\" | sudo -S chown -R $PI_USER:1001 \"$REMOTE_DATA_PATH\""
+run_ssh "echo \"$PASSWORD\" | sudo -S find \"$REMOTE_DATA_PATH\" -type d -exec chmod 770 {} +"
+run_ssh "echo \"$PASSWORD\" | sudo -S find \"$REMOTE_DATA_PATH\" -type f -exec chmod 660 {} +"
 
 
 echo "✅ Backup restored successfully."

--- a/deploy/start-worktree.sh
+++ b/deploy/start-worktree.sh
@@ -61,26 +61,27 @@ else
   git -C "$repo_root" worktree add -b "$branch_name" "$target_dir" "$base_branch"
 fi
 
+mkdir -p "${target_dir}/data/backups"
+
+if command -v bun >/dev/null 2>&1; then
+  echo "Installing dependencies in ${target_dir} without lifecycle scripts"
+  bun install --cwd "$target_dir" --ignore-scripts
+else
+  echo "Bun not found; skipping dependency install."
+fi
+
 source_env="${main_repo_root}/deploy/.env"
 dest_env="${target_dir}/deploy/.env"
 
 if [[ -f "$source_env" && ! -f "$dest_env" ]]; then
   mkdir -p "$(dirname "$dest_env")"
   cp "$source_env" "$dest_env"
+  chmod 600 "$dest_env"
   echo "Copied .env to ${dest_env}"
 elif [[ -f "$dest_env" ]]; then
   echo ".env already exists at ${dest_env}"
 else
   echo "No .env found to copy from ${source_env}"
-fi
-
-mkdir -p "${target_dir}/data/backups"
-
-if command -v bun >/dev/null 2>&1; then
-  echo "Installing dependencies in ${target_dir}"
-  bun install --cwd "$target_dir"
-else
-  echo "Bun not found; skipping dependency install."
 fi
 
 echo "Worktree ready at ${target_dir}"


### PR DESCRIPTION
## Summary
- create SSH multiplex control sockets under a private mktemp directory instead of a predictable tmp path
- run worktree dependency installs before copying deploy env files and disable lifecycle scripts for that helper install
- stop restoring data as world-writable; restored files are owner/container-group writable instead
- move default local backup storage out of the repo and write backup files/directories with owner-only local permissions
- pin the Bun Docker image tag via BUN_IMAGE instead of using a mutable alpine tag

## Verification
- bash -n deploy/deploy.sh deploy/start-worktree.sh deploy/restore.sh deploy/build-and-push.sh
- focused rg search confirmed the previous unsafe patterns are absent

Security findings: ce5fbd81c0248191be59a1fd1b28ac99, 7a71e696e4448191a0ddeb96daf1b4ba, df55451899f08191b5d968062936c4a5, cde26703cff08191bdd5f5df58b552c8, 24ad8c671a548191bf01d4ed78e53657