### PR TITLE
Bound cost dashboard day enumeration

### DIFF
--- a/src/app/__tests__/costDashboardAnalytics.test.ts
+++ b/src/app/__tests__/costDashboardAnalytics.test.ts
@@ -1,7 +1,9 @@
 import {
   buildCostDashboardAnalytics,
   collectUniqueDayKeysForPeriods,
+  enumerateLocalDayKeysBetween,
   getUniquePeriodDayCount,
+  MAX_DASHBOARD_DAY_ENUMERATION,
 } from '@/app/lib/costDashboardAnalytics';
 import { calculateCostSummary, calculateCountryBreakdowns } from '@/app/lib/costUtils';
 import type { CostTrackingData, Expense } from '@/app/types';
@@ -391,5 +393,41 @@ describe('costDashboardAnalytics', () => {
     );
 
     expect(dayKeys).toEqual(['2026-01-03', '2026-01-04', '2026-01-05']);
+  });
+
+  it('refuses to enumerate dashboard day ranges above the safety cap', () => {
+    const safeEnd = new Date('2036-01-08T00:00:00.000Z');
+    const unsafeEnd = new Date('2036-01-09T00:00:00.000Z');
+
+    expect(enumerateLocalDayKeysBetween('2026-01-01', safeEnd)).toHaveLength(MAX_DASHBOARD_DAY_ENUMERATION);
+    expect(enumerateLocalDayKeysBetween('2026-01-01', unsafeEnd)).toEqual([]);
+  });
+
+  it('treats oversized configured country periods as unavailable instead of looping through them', () => {
+    const dayKeys = collectUniqueDayKeysForPeriods([
+      {
+        id: 'oversized-period',
+        startDate: new Date('2026-01-01T00:00:00.000Z'),
+        endDate: new Date('2076-01-01T00:00:00.000Z'),
+      },
+    ]);
+
+    expect(dayKeys).toEqual([]);
+  });
+
+  it('does not build an active dashboard window for oversized trip date spans', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2080-01-01T12:00:00.000Z'));
+
+    const costData = buildBaseCostData();
+    costData.tripStartDate = new Date('2026-01-01T00:00:00.000Z');
+    costData.tripEndDate = new Date('2080-01-01T00:00:00.000Z');
+
+    const costSummary = calculateCostSummary(costData);
+    const analytics = buildCostDashboardAnalytics(costSummary, costData, []);
+
+    expect(analytics.tripWindow.dayKeys).toEqual([]);
+    expect(analytics.tripWindow.dayCount).toBe(0);
+    expect(analytics.includedDays).toBe(0);
   });
 });

--- a/src/app/lib/costDashboardAnalytics.ts
+++ b/src/app/lib/costDashboardAnalytics.ts
@@ -8,6 +8,7 @@ import { formatLocalDateInput, getTodayLocalDay, parseDateAsLocalDay } from '@/a
 
 // Kept local to avoid creating a circular dependency on costUtils for one label constant.
 const REFUNDS_CATEGORY_NAME = 'Refunds';
+export const MAX_DASHBOARD_DAY_ENUMERATION = 3660;
 
 export type DashboardTripWindow = {
   start: Date | null;
@@ -76,10 +77,26 @@ function getEarlierDate(left: Date, right: Date): Date {
   return left < right ? left : right;
 }
 
+function getUtcLocalDayTimestamp(date: Date): number {
+  return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function getInclusiveLocalDaySpan(start: Date, end: Date): number {
+  const startTimestamp = getUtcLocalDayTimestamp(start);
+  const endTimestamp = getUtcLocalDayTimestamp(end);
+  const daySpan = Math.floor((endTimestamp - startTimestamp) / 86400000) + 1;
+  return Number.isFinite(daySpan) ? daySpan : 0;
+}
+
 export function enumerateLocalDayKeysBetween(startInput: Date | string, endInput: Date | string): string[] {
   const start = normalizeDate(startInput);
   const end = normalizeDate(endInput);
   if (!start || !end || end < start) {
+    return [];
+  }
+
+  const daySpan = getInclusiveLocalDaySpan(start, end);
+  if (daySpan <= 0 || daySpan > MAX_DASHBOARD_DAY_ENUMERATION) {
     return [];
   }
 

--- a/src/app/lib/costDashboardAnalytics.ts
+++ b/src/app/lib/costDashboardAnalytics.ts
@@ -8,6 +8,7 @@ import { formatLocalDateInput, getTodayLocalDay, parseDateAsLocalDay } from '@/a
 
 // Kept local to avoid creating a circular dependency on costUtils for one label constant.
 const REFUNDS_CATEGORY_NAME = 'Refunds';
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
 export const MAX_DASHBOARD_DAY_ENUMERATION = 3660;
 
 export type DashboardTripWindow = {
@@ -84,7 +85,7 @@ function getUtcLocalDayTimestamp(date: Date): number {
 function getInclusiveLocalDaySpan(start: Date, end: Date): number {
   const startTimestamp = getUtcLocalDayTimestamp(start);
   const endTimestamp = getUtcLocalDayTimestamp(end);
-  const daySpan = Math.floor((endTimestamp - startTimestamp) / 86400000) + 1;
+  const daySpan = Math.floor((endTimestamp - startTimestamp) / MS_PER_DAY) + 1;
   return Number.isFinite(daySpan) ? daySpan : 0;
 }
 


### PR DESCRIPTION
## Summary
- add a safety cap before cost dashboard analytics enumerate local day keys
- apply the cap to trip windows and configured country periods by sharing the guarded day enumeration helper
- add regression tests for capped helper ranges, oversized country periods, and oversized trip spans

## Verification
- focused costDashboardAnalytics Jest suite passed
- focused ESLint for costDashboardAnalytics source and test passed

Security finding: 676f0008a36c8191b64b5d233b49d7c9