### PR TITLE
Bound route geometry ingestion

### DIFF
--- a/src/app/__tests__/api/travel-data-auth-cache.test.ts
+++ b/src/app/__tests__/api/travel-data-auth-cache.test.ts
@@ -4,8 +4,9 @@
 
 import { NextRequest } from 'next/server';
 
-import { DELETE, GET, PATCH } from '@/app/api/travel-data/route';
+import { DELETE, GET, PATCH, PUT } from '@/app/api/travel-data/route';
 import { deleteTripWithBackup, loadUnifiedTripData, updateTravelData } from '@/app/lib/unifiedDataService';
+import { MAX_ROUTE_POINTS_PER_ROUTE } from '@/app/lib/routePointValidation';
 
 jest.mock('@/app/lib/server-domains', () => ({
   __esModule: true,
@@ -204,5 +205,58 @@ describe('travel-data API auth and cache boundary', () => {
     expect(JSON.stringify(result)).not.toContain('private-booking-code');
     expect(result.accommodations[0].costTrackingLinks).toBeUndefined();
     expect(result.locations[0].accommodationIds).toBeUndefined();
+  });
+
+  it('rejects oversized route point geometry on full trip updates', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+
+    const response = await PUT(
+      new NextRequest('https://admin.example.test/api/travel-data?id=trip-1', {
+        method: 'PUT',
+        headers: { host: 'admin.example.test' },
+        body: JSON.stringify({
+          title: 'Trip',
+          routes: [
+            {
+              id: 'route-1',
+              from: 'A',
+              to: 'B',
+              routePoints: Array.from(
+                { length: MAX_ROUTE_POINTS_PER_ROUTE + 1 },
+                () => [48.8566, 2.3522]
+              )
+            }
+          ]
+        })
+      })
+    );
+    const result = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(result.error).toContain(`more than ${MAX_ROUTE_POINTS_PER_ROUTE} points`);
+    expect(mockUpdateTravelData).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed route point geometry on route-point PATCH updates', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+
+    const response = await PATCH(
+      new NextRequest('https://admin.example.test/api/travel-data?id=trip-1', {
+        method: 'PATCH',
+        headers: { host: 'admin.example.test' },
+        body: JSON.stringify({
+          routeUpdate: {
+            routeId: 'route-1',
+            routePoints: [[91, 2.3522]]
+          }
+        })
+      })
+    );
+    const result = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(result.error).toBe('Route route-1 routePoints[0] must be a valid [latitude, longitude] pair');
+    expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
+    expect(mockUpdateTravelData).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/travel-data/route.ts
+++ b/src/app/api/travel-data/route.ts
@@ -5,7 +5,11 @@ import { isAdminDomain, isAdminHost } from '@/app/lib/server-domains';
 import { validateAndNormalizeCompositeRoute } from '@/app/lib/compositeRouteValidation';
 import { applyTravelDataDelta, isTravelDataDelta, isTravelDataDeltaEmpty } from '@/app/lib/travelDataDelta';
 import { dateReviver } from '@/app/lib/jsonDateReviver';
-import { MAX_ROUTE_POINTS_PER_UPDATE, validateRoutePoints } from '@/app/lib/routePointValidation';
+import {
+  MAX_ROUTE_POINTS_PER_TRIP,
+  MAX_ROUTE_POINTS_PER_UPDATE,
+  validateRoutePoints
+} from '@/app/lib/routePointValidation';
 import type { TravelData } from '@/app/types';
 import { parseDateAsLocalDay } from '@/app/lib/localDateUtils';
 
@@ -28,11 +32,15 @@ type RoutePayload = RouteSegmentPayload & {
 };
 
 const validateSubmittedRoutePoints = (
-  routes?: Array<Partial<RoutePayload> & { id?: string }>
+  routes?: Array<Partial<RoutePayload> & { id?: string }>,
+  options: { totalLimit?: number; totalLabel?: string } = {}
 ): { error?: string } => {
   if (!routes) return {};
 
+  const totalLimit = options.totalLimit ?? MAX_ROUTE_POINTS_PER_UPDATE;
+  const totalLabel = options.totalLabel ?? 'Route update';
   let totalRoutePoints = 0;
+
   for (const route of routes) {
     const routeId = route.id ?? 'unknown';
     const routePointValidation = validateRoutePoints(route.routePoints, `Route ${routeId} routePoints`);
@@ -54,9 +62,9 @@ const validateSubmittedRoutePoints = (
       totalRoutePoints += segmentPointValidation.points.length;
     }
 
-    if (totalRoutePoints > MAX_ROUTE_POINTS_PER_UPDATE) {
+    if (totalRoutePoints > totalLimit) {
       return {
-        error: `Route update cannot contain more than ${MAX_ROUTE_POINTS_PER_UPDATE} total route points`
+        error: `${totalLabel} cannot contain more than ${totalLimit} total route points`
       };
     }
   }
@@ -66,12 +74,15 @@ const validateSubmittedRoutePoints = (
 
 const normalizeCompositeRoutes = (
   routes?: RoutePayload[],
-  options: { validateRoutePoints?: boolean } = {}
+  options: { validateRoutePoints?: boolean; totalRoutePointsLimit?: number; totalLabel?: string } = {}
 ) => {
   if (!routes) return { routes };
 
   if (options.validateRoutePoints ?? true) {
-    const routePointValidation = validateSubmittedRoutePoints(routes);
+    const routePointValidation = validateSubmittedRoutePoints(routes, {
+      totalLimit: options.totalRoutePointsLimit ?? MAX_ROUTE_POINTS_PER_TRIP,
+      totalLabel: options.totalLabel ?? 'Trip'
+    });
     if (routePointValidation.error) {
       return { error: routePointValidation.error };
     }
@@ -381,10 +392,7 @@ export async function PATCH(request: NextRequest) {
       // accommodation endpoints and not part of TravelDataDelta.
       const merged = applyTravelDataDelta(baseTravelData, delta);
 
-      const { routes, error } = normalizeCompositeRoutes(
-        merged.routes as unknown as RoutePayload[],
-        { validateRoutePoints: false }
-      );
+      const { routes, error } = normalizeCompositeRoutes(merged.routes as unknown as RoutePayload[]);
       if (error) {
         return NextResponse.json(
           { error },
@@ -466,6 +474,17 @@ export async function PATCH(request: NextRequest) {
         }
         
         if (updatedCount > 0) {
+          const routePointValidation = validateSubmittedRoutePoints(
+            unifiedData.travelData.routes as unknown as RoutePayload[],
+            { totalLimit: MAX_ROUTE_POINTS_PER_TRIP, totalLabel: 'Trip' }
+          );
+          if (routePointValidation.error) {
+            return NextResponse.json(
+              { error: routePointValidation.error },
+              { status: 400 }
+            );
+          }
+
           console.log('[PATCH] Saving %d route updates to trip %s', updatedCount, id);
           // Save the updated data - pass only the route updates
           try {
@@ -522,6 +541,17 @@ export async function PATCH(request: NextRequest) {
         const routeIndex = unifiedData.travelData.routes.findIndex((route: { id: string }) => route.id === routeId);
         if (routeIndex >= 0) {
           (unifiedData.travelData.routes[routeIndex] as { routePoints?: [number, number][] }).routePoints = routePoints;
+
+          const routePointValidation = validateSubmittedRoutePoints(
+            unifiedData.travelData.routes as unknown as RoutePayload[],
+            { totalLimit: MAX_ROUTE_POINTS_PER_TRIP, totalLabel: 'Trip' }
+          );
+          if (routePointValidation.error) {
+            return NextResponse.json(
+              { error: routePointValidation.error },
+              { status: 400 }
+            );
+          }
           
           // Save the updated data - pass only the route updates
           await updateTravelData(id, {

--- a/src/app/api/travel-data/route.ts
+++ b/src/app/api/travel-data/route.ts
@@ -5,6 +5,7 @@ import { isAdminDomain, isAdminHost } from '@/app/lib/server-domains';
 import { validateAndNormalizeCompositeRoute } from '@/app/lib/compositeRouteValidation';
 import { applyTravelDataDelta, isTravelDataDelta, isTravelDataDeltaEmpty } from '@/app/lib/travelDataDelta';
 import { dateReviver } from '@/app/lib/jsonDateReviver';
+import { MAX_ROUTE_POINTS_PER_UPDATE, validateRoutePoints } from '@/app/lib/routePointValidation';
 import type { TravelData } from '@/app/types';
 import { parseDateAsLocalDay } from '@/app/lib/localDateUtils';
 
@@ -18,6 +19,7 @@ type RouteSegmentPayload = {
   to: string;
   fromCoords?: [number, number];
   toCoords?: [number, number];
+  routePoints?: [number, number][];
 };
 
 type RoutePayload = RouteSegmentPayload & {
@@ -25,8 +27,55 @@ type RoutePayload = RouteSegmentPayload & {
   subRoutes?: RouteSegmentPayload[];
 };
 
-const normalizeCompositeRoutes = (routes?: RoutePayload[]) => {
+const validateSubmittedRoutePoints = (
+  routes?: Array<Partial<RoutePayload> & { id?: string }>
+): { error?: string } => {
+  if (!routes) return {};
+
+  let totalRoutePoints = 0;
+  for (const route of routes) {
+    const routeId = route.id ?? 'unknown';
+    const routePointValidation = validateRoutePoints(route.routePoints, `Route ${routeId} routePoints`);
+    if (!routePointValidation.ok) {
+      return { error: routePointValidation.error };
+    }
+    totalRoutePoints += routePointValidation.points.length;
+
+    const subRoutes = route.subRoutes ?? [];
+    for (let index = 0; index < subRoutes.length; index += 1) {
+      const segment = subRoutes[index];
+      const segmentPointValidation = validateRoutePoints(
+        segment.routePoints,
+        `Route ${routeId} sub-route ${index + 1} routePoints`
+      );
+      if (!segmentPointValidation.ok) {
+        return { error: segmentPointValidation.error };
+      }
+      totalRoutePoints += segmentPointValidation.points.length;
+    }
+
+    if (totalRoutePoints > MAX_ROUTE_POINTS_PER_UPDATE) {
+      return {
+        error: `Route update cannot contain more than ${MAX_ROUTE_POINTS_PER_UPDATE} total route points`
+      };
+    }
+  }
+
+  return {};
+};
+
+const normalizeCompositeRoutes = (
+  routes?: RoutePayload[],
+  options: { validateRoutePoints?: boolean } = {}
+) => {
   if (!routes) return { routes };
+
+  if (options.validateRoutePoints ?? true) {
+    const routePointValidation = validateSubmittedRoutePoints(routes);
+    if (routePointValidation.error) {
+      return { error: routePointValidation.error };
+    }
+  }
 
   const normalized = routes.map((route) => {
     const validation = validateAndNormalizeCompositeRoute(route);
@@ -296,6 +345,17 @@ export async function PATCH(request: NextRequest) {
         });
       }
 
+      const routePointValidation = validateSubmittedRoutePoints([
+        ...(delta.routes?.added ?? []),
+        ...(delta.routes?.updated ?? [])
+      ] as Array<Partial<RoutePayload> & { id?: string }>);
+      if (routePointValidation.error) {
+        return NextResponse.json(
+          { error: routePointValidation.error },
+          { status: 400 }
+        );
+      }
+
       const unifiedData = await loadUnifiedTripData(id);
       if (!unifiedData) {
         return NextResponse.json(
@@ -321,7 +381,10 @@ export async function PATCH(request: NextRequest) {
       // accommodation endpoints and not part of TravelDataDelta.
       const merged = applyTravelDataDelta(baseTravelData, delta);
 
-      const { routes, error } = normalizeCompositeRoutes(merged.routes as unknown as RoutePayload[]);
+      const { routes, error } = normalizeCompositeRoutes(
+        merged.routes as unknown as RoutePayload[],
+        { validateRoutePoints: false }
+      );
       if (error) {
         return NextResponse.json(
           { error },
@@ -349,6 +412,25 @@ export async function PATCH(request: NextRequest) {
     // Handle batch route point updates
     if (updateRequest.batchRouteUpdate) {
       const updates = updateRequest.batchRouteUpdate as Array<{routeId: string, routePoints: [number, number][]}>;
+      let totalRoutePoints = 0;
+      for (const update of updates) {
+        const validation = validateRoutePoints(update.routePoints, `Route ${update.routeId} routePoints`);
+        if (!validation.ok) {
+          return NextResponse.json(
+            { error: validation.error },
+            { status: 400 }
+          );
+        }
+
+        totalRoutePoints += validation.points.length;
+        if (totalRoutePoints > MAX_ROUTE_POINTS_PER_UPDATE) {
+          return NextResponse.json(
+            { error: `Route update cannot contain more than ${MAX_ROUTE_POINTS_PER_UPDATE} total route points` },
+            { status: 400 }
+          );
+        }
+      }
+
       console.log('[PATCH] Processing batch route update for trip %s with %d routes', id, updates.length);
       
       // Load current unified data
@@ -418,6 +500,13 @@ export async function PATCH(request: NextRequest) {
     // Handle single route point updates (backwards compatibility)
     if (updateRequest.routeUpdate) {
       const { routeId, routePoints } = updateRequest.routeUpdate;
+      const validation = validateRoutePoints(routePoints, `Route ${routeId} routePoints`);
+      if (!validation.ok) {
+        return NextResponse.json(
+          { error: validation.error },
+          { status: 400 }
+        );
+      }
       
       // Load current unified data
       const unifiedData = await loadUnifiedTripData(id);

--- a/src/app/lib/railRouting.ts
+++ b/src/app/lib/railRouting.ts
@@ -59,6 +59,13 @@ const DEFAULT_OVERPASS_ENDPOINTS = [
   'https://overpass.kumi.systems/api/interpreter'
 ];
 
+class RailGraphSizeLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RailGraphSizeLimitError';
+  }
+}
+
 const getOverpassEndpoints = (): string[] => {
   const configured = (
     process.env.NEXT_PUBLIC_RAIL_OVERPASS_ENDPOINTS ??
@@ -168,7 +175,7 @@ const buildRailGraph = (
   data: OverpassResponse
 ): { nodes: Map<number, Coordinate>; edges: Map<number, Edge[]> } => {
   if ((data.elements?.length ?? 0) > MAX_RAIL_GRAPH_ELEMENTS) {
-    throw new Error(`Overpass rail response exceeded ${MAX_RAIL_GRAPH_ELEMENTS} elements`);
+    throw new RailGraphSizeLimitError(`Overpass rail response exceeded ${MAX_RAIL_GRAPH_ELEMENTS} elements`);
   }
 
   const nodes = new Map<number, Coordinate>();
@@ -189,7 +196,7 @@ const buildRailGraph = (
   for (const element of data.elements ?? []) {
     if (isNode(element)) {
       if (nodes.size >= MAX_RAIL_GRAPH_NODES) {
-        throw new Error(`Overpass rail response exceeded ${MAX_RAIL_GRAPH_NODES} nodes`);
+        throw new RailGraphSizeLimitError(`Overpass rail response exceeded ${MAX_RAIL_GRAPH_NODES} nodes`);
       }
       nodes.set(element.id, [element.lat, element.lon]);
       continue;
@@ -206,7 +213,7 @@ const buildRailGraph = (
   const addEdge = (fromId: number, toId: number, weight: number) => {
     edgeCount += 1;
     if (edgeCount > MAX_RAIL_GRAPH_EDGES) {
-      throw new Error(`Overpass rail response exceeded ${MAX_RAIL_GRAPH_EDGES} edges`);
+      throw new RailGraphSizeLimitError(`Overpass rail response exceeded ${MAX_RAIL_GRAPH_EDGES} edges`);
     }
 
     if (!edges.has(fromId)) {
@@ -447,6 +454,9 @@ export const generateRailRoutePoints = async (
       return ensureEndpoints(fromCoordinates, toCoordinates, pathPoints);
     } catch (error) {
       console.warn('[railRouting] Failed to generate OSM rail route:', error);
+      if (error instanceof RailGraphSizeLimitError) {
+        break;
+      }
     }
   }
 

--- a/src/app/lib/railRouting.ts
+++ b/src/app/lib/railRouting.ts
@@ -1,4 +1,9 @@
 import type { Transportation } from '@/app/types';
+import {
+  MAX_RAIL_GRAPH_EDGES,
+  MAX_RAIL_GRAPH_ELEMENTS,
+  MAX_RAIL_GRAPH_NODES
+} from '@/app/lib/routePointValidation';
 
 type Coordinate = [number, number];
 
@@ -162,6 +167,10 @@ const fetchOverpass = async (query: string): Promise<OverpassResponse> => {
 const buildRailGraph = (
   data: OverpassResponse
 ): { nodes: Map<number, Coordinate>; edges: Map<number, Edge[]> } => {
+  if ((data.elements?.length ?? 0) > MAX_RAIL_GRAPH_ELEMENTS) {
+    throw new Error(`Overpass rail response exceeded ${MAX_RAIL_GRAPH_ELEMENTS} elements`);
+  }
+
   const nodes = new Map<number, Coordinate>();
   const ways: OverpassWay[] = [];
 
@@ -179,6 +188,9 @@ const buildRailGraph = (
 
   for (const element of data.elements ?? []) {
     if (isNode(element)) {
+      if (nodes.size >= MAX_RAIL_GRAPH_NODES) {
+        throw new Error(`Overpass rail response exceeded ${MAX_RAIL_GRAPH_NODES} nodes`);
+      }
       nodes.set(element.id, [element.lat, element.lon]);
       continue;
     }
@@ -191,12 +203,19 @@ const buildRailGraph = (
   const edges = new Map<number, Edge[]>();
 
   const addEdge = (fromId: number, toId: number, weight: number) => {
+    edgeCount += 1;
+    if (edgeCount > MAX_RAIL_GRAPH_EDGES) {
+      throw new Error(`Overpass rail response exceeded ${MAX_RAIL_GRAPH_EDGES} edges`);
+    }
+
     if (!edges.has(fromId)) {
       edges.set(fromId, []);
     }
 
     edges.get(fromId)!.push({ to: toId, weight });
   };
+
+  let edgeCount = 0;
 
   for (const way of ways) {
     const nodeIds = way.nodes ?? [];

--- a/src/app/lib/railRouting.ts
+++ b/src/app/lib/railRouting.ts
@@ -201,6 +201,7 @@ const buildRailGraph = (
   }
 
   const edges = new Map<number, Edge[]>();
+  let edgeCount = 0;
 
   const addEdge = (fromId: number, toId: number, weight: number) => {
     edgeCount += 1;
@@ -214,8 +215,6 @@ const buildRailGraph = (
 
     edges.get(fromId)!.push({ to: toId, weight });
   };
-
-  let edgeCount = 0;
 
   for (const way of ways) {
     const nodeIds = way.nodes ?? [];

--- a/src/app/lib/routePointValidation.ts
+++ b/src/app/lib/routePointValidation.ts
@@ -1,0 +1,57 @@
+export type RoutePoint = [number, number];
+
+export const MAX_ROUTE_POINTS_PER_ROUTE = 100000;
+export const MAX_ROUTE_POINTS_PER_UPDATE = 250000;
+export const MAX_RAIL_GRAPH_ELEMENTS = 50000;
+export const MAX_RAIL_GRAPH_NODES = 40000;
+export const MAX_RAIL_GRAPH_EDGES = 100000;
+
+type RoutePointValidationResult =
+  | { ok: true; points: RoutePoint[] }
+  | { ok: false; error: string };
+
+const isValidRoutePoint = (point: unknown): point is RoutePoint => {
+  if (!Array.isArray(point) || point.length !== 2) {
+    return false;
+  }
+
+  const [lat, lng] = point;
+  return (
+    typeof lat === 'number' &&
+    typeof lng === 'number' &&
+    Number.isFinite(lat) &&
+    Number.isFinite(lng) &&
+    lat >= -90 &&
+    lat <= 90 &&
+    lng >= -180 &&
+    lng <= 180
+  );
+};
+
+export const validateRoutePoints = (
+  points: unknown,
+  label = 'routePoints'
+): RoutePointValidationResult => {
+  if (points === undefined) {
+    return { ok: true, points: [] };
+  }
+
+  if (!Array.isArray(points)) {
+    return { ok: false, error: `${label} must be an array` };
+  }
+
+  if (points.length > MAX_ROUTE_POINTS_PER_ROUTE) {
+    return {
+      ok: false,
+      error: `${label} cannot contain more than ${MAX_ROUTE_POINTS_PER_ROUTE} points`
+    };
+  }
+
+  for (let index = 0; index < points.length; index += 1) {
+    if (!isValidRoutePoint(points[index])) {
+      return { ok: false, error: `${label}[${index}] must be a valid [latitude, longitude] pair` };
+    }
+  }
+
+  return { ok: true, points: points as RoutePoint[] };
+};

--- a/src/app/lib/routePointValidation.ts
+++ b/src/app/lib/routePointValidation.ts
@@ -2,6 +2,7 @@ export type RoutePoint = [number, number];
 
 export const MAX_ROUTE_POINTS_PER_ROUTE = 100000;
 export const MAX_ROUTE_POINTS_PER_UPDATE = 250000;
+export const MAX_ROUTE_POINTS_PER_TRIP = 1000000;
 export const MAX_RAIL_GRAPH_ELEMENTS = 50000;
 export const MAX_RAIL_GRAPH_NODES = 40000;
 export const MAX_RAIL_GRAPH_EDGES = 100000;

--- a/src/app/lib/routePointValidation.ts
+++ b/src/app/lib/routePointValidation.ts
@@ -32,7 +32,7 @@ export const validateRoutePoints = (
   points: unknown,
   label = 'routePoints'
 ): RoutePointValidationResult => {
-  if (points === undefined) {
+  if (points === undefined || points === null) {
     return { ok: true, points: [] };
   }
 


### PR DESCRIPTION
## Summary
- add shared validation for submitted routePoints shape, coordinate range, and high geometry ceilings
- reject oversized or malformed route geometry on full travel-data saves and route-point PATCH updates before loading/saving trip data
- bound untrusted Overpass rail graph size while preserving legitimate large generated route paths

## Verification
- bun run test:unit -- src/app/__tests__/api/travel-data-auth-cache.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint src/app/api/travel-data/route.ts src/app/lib/railRouting.ts src/app/lib/routePointValidation.ts src/app/__tests__/api/travel-data-auth-cache.test.ts --max-warnings=0
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation for route point coordinates (latitude/longitude ranges) and maximum point counts; invalid data returns 400 errors with descriptive messages
  * Rail-graph responses are capped with hard limits to prevent oversized data payloads

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->