### PR TITLE
Harden route name handling

### DIFF
--- a/src/app/__tests__/lib/compositeRouteValidation.test.ts
+++ b/src/app/__tests__/lib/compositeRouteValidation.test.ts
@@ -71,4 +71,37 @@ describe('validateAndNormalizeCompositeRoute', () => {
     expect(result.normalizedRoute.subRoutes?.[0].distanceOverride).toBe(12.5);
     expect(result.normalizedRoute.subRoutes?.[1].distanceOverride).toBe(8.25);
   });
+
+  it('rejects malformed route names without throwing', () => {
+    const result = validateAndNormalizeCompositeRoute({
+      from: { label: 'A' },
+      to: 'B',
+      subRoutes: [
+        { from: 'A', to: 'B' }
+      ]
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected malformed route name validation failure');
+    }
+    expect(result.error).toEqual({ code: 'invalid_route_name', field: 'from' });
+  });
+
+  it('rejects malformed sub-route names without throwing', () => {
+    const result = validateAndNormalizeCompositeRoute({
+      from: 'A',
+      to: 'C',
+      subRoutes: [
+        { from: 'A', to: 'B' },
+        { from: null, to: 'C' }
+      ]
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected malformed sub-route validation failure');
+    }
+    expect(result.error).toEqual({ code: 'invalid_route_name', field: 'from', segmentNumber: 2 });
+  });
 });

--- a/src/app/__tests__/lib/compositeRouteValidation.test.ts
+++ b/src/app/__tests__/lib/compositeRouteValidation.test.ts
@@ -53,6 +53,36 @@ describe('validateAndNormalizeCompositeRoute', () => {
     expect(result.normalizedRoute.to).toBe('Known End');
   });
 
+  it('rejects blank standalone route names', () => {
+    const result = validateAndNormalizeCompositeRoute({
+      from: '',
+      to: 'B'
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected blank route name validation failure');
+    }
+    expect(result.error).toEqual({ code: 'invalid_route_name', field: 'from' });
+  });
+
+  it('rejects blank sub-route names', () => {
+    const result = validateAndNormalizeCompositeRoute({
+      from: 'A',
+      to: 'C',
+      subRoutes: [
+        { from: 'A', to: 'B' },
+        { from: ' ', to: 'C' }
+      ]
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected blank sub-route validation failure');
+    }
+    expect(result.error).toEqual({ code: 'invalid_route_name', field: 'from', segmentNumber: 2 });
+  });
+
   it('preserves segment distance overrides after normalization', () => {
     const result = validateAndNormalizeCompositeRoute({
       from: 'A',

--- a/src/app/__tests__/lib/currentTripStatus.test.ts
+++ b/src/app/__tests__/lib/currentTripStatus.test.ts
@@ -17,6 +17,20 @@ describe('getCurrentTripStatus', () => {
     );
   });
 
+  it('trims route endpoint names before rendering current travel status', () => {
+    const locations: LocationTiming[] = [
+      { name: 'Puno', date: utc('2024-02-04'), endDate: utc('2024-02-06') },
+    ];
+    const routes: RouteTiming[] = [
+      { from: '  Puno  ', to: '  Cusco ', departureTime: utc('2024-02-06') },
+    ];
+    const now = new Date('2024-02-06T10:00:00Z');
+
+    expect(getCurrentTripStatus(locations, routes, now)).toBe(
+      'Current location: Travelling today between Puno and Cusco'
+    );
+  });
+
   it('returns travel message when two locations overlap today', () => {
     const locations: LocationTiming[] = [
       { name: 'Puno', date: utc('2024-02-04'), endDate: utc('2024-02-06') },

--- a/src/app/__tests__/lib/currentTripStatus.test.ts
+++ b/src/app/__tests__/lib/currentTripStatus.test.ts
@@ -103,4 +103,34 @@ describe('getCurrentTripStatus', () => {
       'Current location: Puno'
     );
   });
+
+  it('ignores malformed route endpoint names instead of crashing status rendering', () => {
+    const locations: LocationTiming[] = [
+      { name: 'Puno', date: utc('2024-02-04'), endDate: utc('2024-02-06') },
+    ];
+    const routes: RouteTiming[] = [
+      { from: { name: 'Puno' }, to: 'Cusco', departureTime: utc('2024-02-06') },
+      { from: 'Puno', to: null, departureTime: utc('2024-02-06') },
+    ];
+    const now = new Date('2024-02-06T10:00:00Z');
+
+    expect(getCurrentTripStatus(locations, routes, now)).toBe(
+      'Current location: Puno'
+    );
+  });
+
+  it('falls back to location names when overlap route endpoint names are malformed', () => {
+    const locations: LocationTiming[] = [
+      { name: 'Puno', date: utc('2024-02-04'), endDate: utc('2024-02-06') },
+      { name: 'Cusco', date: utc('2024-02-06'), endDate: utc('2024-02-10') },
+    ];
+    const routes: RouteTiming[] = [
+      { from: ['Puno'], to: 'Cusco' },
+    ];
+    const now = new Date('2024-02-06T10:00:00Z');
+
+    expect(getCurrentTripStatus(locations, routes, now)).toBe(
+      'Current location: Travelling today between Puno and Cusco'
+    );
+  });
 });

--- a/src/app/api/travel-data/route.ts
+++ b/src/app/api/travel-data/route.ts
@@ -95,6 +95,12 @@ const normalizeCompositeRoutes = (
     }
 
     switch (validation.error.code) {
+      case 'invalid_route_name':
+        return {
+          error: validation.error.segmentNumber
+            ? `Route ${route.id} sub-route ${validation.error.segmentNumber} ${validation.error.field} must be a non-empty string`
+            : `Route ${route.id} ${validation.error.field} must be a non-empty string`
+        };
       case 'from_mismatch':
         return { error: `Route ${route.id} from does not match sub-route start` };
       case 'to_mismatch':

--- a/src/app/lib/compositeRouteValidation.ts
+++ b/src/app/lib/compositeRouteValidation.ts
@@ -1,6 +1,6 @@
 type RouteSegmentLike = {
-  from?: string;
-  to?: string;
+  from?: unknown;
+  to?: unknown;
   fromCoords?: [number, number];
   toCoords?: [number, number];
   distanceOverride?: number;
@@ -12,6 +12,7 @@ export type CompositeRouteLike = RouteSegmentLike & {
 };
 
 export type CompositeRouteValidationError =
+  | { code: 'invalid_route_name'; field: 'from' | 'to'; segmentNumber?: number }
   | { code: 'from_mismatch' }
   | { code: 'to_mismatch' }
   | { code: 'from_coords_mismatch' }
@@ -25,9 +26,13 @@ export type CompositeRouteValidationResult =
 // Allow sub-meter coordinate drift from serialization/geocoding differences.
 const COORD_EPSILON = 1e-6;
 
-const normalizeLocationName = (value?: string) => value?.trim().toLowerCase() || '';
+const isValidOptionalLocationName = (value: unknown): value is string | undefined =>
+  value === undefined || typeof value === 'string';
 
-const isSameLocationName = (left?: string, right?: string) => {
+const normalizeLocationName = (value?: unknown) => typeof value === 'string' ? value.trim().toLowerCase() : '';
+
+const isSameLocationName = (left?: unknown, right?: unknown) => {
+  if (typeof left !== 'string' || typeof right !== 'string') return false;
   if (!left || !right) return false;
   return normalizeLocationName(left) === normalizeLocationName(right);
 };
@@ -57,9 +62,28 @@ const findDisconnectedSegmentNumber = (subRoutes: RouteSegmentLike[]): number | 
 };
 
 export const validateAndNormalizeCompositeRoute = (route: CompositeRouteLike): CompositeRouteValidationResult => {
+  if (!isValidOptionalLocationName(route.from)) {
+    return { ok: false, error: { code: 'invalid_route_name', field: 'from' } };
+  }
+
+  if (!isValidOptionalLocationName(route.to)) {
+    return { ok: false, error: { code: 'invalid_route_name', field: 'to' } };
+  }
+
   const subRoutes = route.subRoutes;
   if (!subRoutes?.length) {
     return { ok: true, normalizedRoute: route };
+  }
+
+  for (let index = 0; index < subRoutes.length; index += 1) {
+    const segment = subRoutes[index];
+    if (!isValidOptionalLocationName(segment.from)) {
+      return { ok: false, error: { code: 'invalid_route_name', field: 'from', segmentNumber: index + 1 } };
+    }
+
+    if (!isValidOptionalLocationName(segment.to)) {
+      return { ok: false, error: { code: 'invalid_route_name', field: 'to', segmentNumber: index + 1 } };
+    }
   }
 
   const first = subRoutes[0];

--- a/src/app/lib/compositeRouteValidation.ts
+++ b/src/app/lib/compositeRouteValidation.ts
@@ -26,15 +26,21 @@ export type CompositeRouteValidationResult =
 // Allow sub-meter coordinate drift from serialization/geocoding differences.
 const COORD_EPSILON = 1e-6;
 
-const isValidOptionalLocationName = (value: unknown): value is string | undefined =>
-  value === undefined || typeof value === 'string';
+const isValidOptionalLocationName = (
+  value: unknown,
+  options: { allowBlank?: boolean } = {}
+): value is string | undefined => {
+  if (value === undefined) return true;
+  if (typeof value !== 'string') return false;
+  return options.allowBlank || value.trim().length > 0;
+};
 
 const normalizeLocationName = (value?: unknown) => typeof value === 'string' ? value.trim().toLowerCase() : '';
 
 const isSameLocationName = (left?: unknown, right?: unknown) => {
-  if (typeof left !== 'string' || typeof right !== 'string') return false;
-  if (!left || !right) return false;
-  return normalizeLocationName(left) === normalizeLocationName(right);
+  const normalizedLeft = normalizeLocationName(left);
+  const normalizedRight = normalizeLocationName(right);
+  return normalizedLeft !== '' && normalizedLeft === normalizedRight;
 };
 
 const isSameCoords = (left?: [number, number], right?: [number, number]) => {
@@ -62,15 +68,17 @@ const findDisconnectedSegmentNumber = (subRoutes: RouteSegmentLike[]): number | 
 };
 
 export const validateAndNormalizeCompositeRoute = (route: CompositeRouteLike): CompositeRouteValidationResult => {
-  if (!isValidOptionalLocationName(route.from)) {
+  const subRoutes = route.subRoutes;
+  const hasSubRoutes = Boolean(subRoutes?.length);
+
+  if (!isValidOptionalLocationName(route.from, { allowBlank: hasSubRoutes })) {
     return { ok: false, error: { code: 'invalid_route_name', field: 'from' } };
   }
 
-  if (!isValidOptionalLocationName(route.to)) {
+  if (!isValidOptionalLocationName(route.to, { allowBlank: hasSubRoutes })) {
     return { ok: false, error: { code: 'invalid_route_name', field: 'to' } };
   }
 
-  const subRoutes = route.subRoutes;
   if (!subRoutes?.length) {
     return { ok: true, normalizedRoute: route };
   }

--- a/src/app/lib/currentTripStatus.ts
+++ b/src/app/lib/currentTripStatus.ts
@@ -24,8 +24,8 @@ const normalizeDate = (value: string | Date | undefined | null): Date | null => 
 
 const isSameDay = (a: Date, b: Date): boolean => a.getTime() === b.getTime();
 const getNonEmptyString = (value: unknown): string | null =>
-  typeof value === 'string' && value.trim().length > 0 ? value : null;
-const getComparableName = (value: unknown): string | null => getNonEmptyString(value)?.trim().toLowerCase() ?? null;
+  typeof value === 'string' ? (value.trim() || null) : null;
+const getComparableName = (value: unknown): string | null => getNonEmptyString(value)?.toLowerCase() ?? null;
 const hasSameName = (left: unknown, right: unknown): boolean => {
   const normalizedLeft = getComparableName(left);
   const normalizedRight = getComparableName(right);

--- a/src/app/lib/currentTripStatus.ts
+++ b/src/app/lib/currentTripStatus.ts
@@ -8,8 +8,8 @@ export type LocationTiming = {
 };
 
 export type RouteTiming = {
-  from: string;
-  to: string;
+  from: unknown;
+  to: unknown;
   date?: string | Date;
   departureTime?: string | Date;
   arrivalTime?: string | Date;
@@ -23,6 +23,14 @@ const normalizeDate = (value: string | Date | undefined | null): Date | null => 
 };
 
 const isSameDay = (a: Date, b: Date): boolean => a.getTime() === b.getTime();
+const getNonEmptyString = (value: unknown): string | null =>
+  typeof value === 'string' && value.trim().length > 0 ? value : null;
+const getComparableName = (value: unknown): string | null => getNonEmptyString(value)?.trim().toLowerCase() ?? null;
+const hasSameName = (left: unknown, right: unknown): boolean => {
+  const normalizedLeft = getComparableName(left);
+  const normalizedRight = getComparableName(right);
+  return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
+};
 
 export const getCurrentTripStatus = (
   locations: LocationTiming[],
@@ -36,12 +44,16 @@ export const getCurrentTripStatus = (
     const departure = normalizeDate(route.departureTime ?? route.date);
     const arrival = normalizeDate(route.arrivalTime ?? route.departureTime ?? route.date);
     if (!departure) continue;
+    const from = getNonEmptyString(route.from);
+    const to = getNonEmptyString(route.to);
+    if (!from || !to) continue;
+
     const routeEnd = arrival && arrival >= departure ? arrival : departure;
     if (today >= departure && today <= routeEnd) {
-      return `Current location: Travelling today between ${route.from} and ${route.to}`;
+      return `Current location: Travelling today between ${from} and ${to}`;
     }
     if (isSameDay(today, departure)) {
-      return `Current location: Travelling today between ${route.from} and ${route.to}`;
+      return `Current location: Travelling today between ${from} and ${to}`;
     }
   }
 
@@ -64,11 +76,11 @@ export const getCurrentTripStatus = (
     // Try to find a matching route between them
     const matchingRoute = routes.find(
       (r) =>
-        r.from.toLowerCase() === departing.name.toLowerCase() &&
-        r.to.toLowerCase() === arriving.name.toLowerCase()
+        hasSameName(r.from, departing.name) &&
+        hasSameName(r.to, arriving.name)
     );
-    const from = matchingRoute ? matchingRoute.from : departing.name;
-    const to = matchingRoute ? matchingRoute.to : arriving.name;
+    const from = getNonEmptyString(matchingRoute?.from) ?? departing.name;
+    const to = getNonEmptyString(matchingRoute?.to) ?? arriving.name;
     return `Current location: Travelling today between ${from} and ${to}`;
   }
 
@@ -77,10 +89,14 @@ export const getCurrentTripStatus = (
     if (isSameDay(today, end)) {
       // Last day at this location — check if there's a route departing from here
       const departingRoute = routes.find(
-        (r) => r.from.toLowerCase() === loc.name.toLowerCase()
+        (r) => hasSameName(r.from, loc.name)
       );
       if (departingRoute) {
-        return `Current location: Travelling today between ${departingRoute.from} and ${departingRoute.to}`;
+        const from = getNonEmptyString(departingRoute.from);
+        const to = getNonEmptyString(departingRoute.to);
+        if (from && to) {
+          return `Current location: Travelling today between ${from} and ${to}`;
+        }
       }
     }
     // Normal single location (or last day with no route)


### PR DESCRIPTION
## Summary
- treat route endpoint names as untrusted values in current-trip status rendering
- skip malformed current-status routes instead of calling string methods on arbitrary JSON values
- reject malformed route/sub-route names during composite route validation with 400 responses instead of crashing route writes

## Verification
- bun run test:unit -- src/app/__tests__/lib/currentTripStatus.test.ts src/app/__tests__/lib/compositeRouteValidation.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint src/app/lib/currentTripStatus.ts src/app/lib/compositeRouteValidation.ts src/app/api/travel-data/route.ts src/app/__tests__/lib/currentTripStatus.test.ts src/app/__tests__/lib/compositeRouteValidation.test.ts --max-warnings=0
- bun run build