### PR TITLE
Validate route transport types

### DIFF
--- a/src/app/__tests__/api/travel-data-auth-cache.test.ts
+++ b/src/app/__tests__/api/travel-data-auth-cache.test.ts
@@ -259,4 +259,83 @@ describe('travel-data API auth and cache boundary', () => {
     expect(mockLoadUnifiedTripData).not.toHaveBeenCalled();
     expect(mockUpdateTravelData).not.toHaveBeenCalled();
   });
+
+  it('coerces stale stored route transport types before validating unrelated delta PATCH updates', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+    mockLoadUnifiedTripData.mockResolvedValue({
+      ...buildTrip(),
+      travelData: {
+        ...buildTrip().travelData,
+        locations: [
+          {
+            id: 'location-1',
+            name: 'Admin Location',
+            coordinates: [52.52, 13.405]
+          }
+        ],
+        routes: [
+          {
+            id: 'route-1',
+            from: 'A',
+            to: 'B',
+            transportType: 'sidecar',
+            subRoutes: [
+              {
+                id: 'segment-1',
+                from: 'A',
+                to: 'B',
+                type: 'wagon'
+              }
+            ]
+          }
+        ]
+      }
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    const response = await PATCH(
+      new NextRequest('https://admin.example.test/api/travel-data?id=trip-1', {
+        method: 'PATCH',
+        headers: { host: 'admin.example.test' },
+        body: JSON.stringify({
+          deltaUpdate: {
+            locations: {
+              updated: [
+                {
+                  id: 'location-1',
+                  name: 'Renamed Location'
+                }
+              ]
+            }
+          }
+        })
+      })
+    );
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result).toEqual({
+      success: true,
+      message: 'Delta applied successfully'
+    });
+    expect(mockUpdateTravelData).toHaveBeenCalledWith('trip-1', expect.objectContaining({
+      locations: [
+        expect.objectContaining({
+          id: 'location-1',
+          name: 'Renamed Location'
+        })
+      ],
+      routes: [
+        expect.objectContaining({
+          id: 'route-1',
+          transportType: 'other',
+          subRoutes: [
+            expect.objectContaining({
+              id: 'segment-1',
+              type: 'other'
+            })
+          ]
+        })
+      ]
+    }));
+  });
 });

--- a/src/app/__tests__/lib/compositeRouteValidation.test.ts
+++ b/src/app/__tests__/lib/compositeRouteValidation.test.ts
@@ -134,4 +134,54 @@ describe('validateAndNormalizeCompositeRoute', () => {
     }
     expect(result.error).toEqual({ code: 'invalid_route_name', field: 'from', segmentNumber: 2 });
   });
+
+  it('rejects unsupported top-level transport types', () => {
+    const result = validateAndNormalizeCompositeRoute({
+      from: 'A',
+      to: 'B',
+      transportType: 'sidecar'
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected invalid transport type validation failure');
+    }
+    expect(result.error).toEqual({ code: 'invalid_transport_type', field: 'transportType' });
+  });
+
+  it('rejects unsupported legacy top-level route types', () => {
+    const result = validateAndNormalizeCompositeRoute({
+      from: 'A',
+      to: 'B',
+      type: 'sidecar'
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected invalid legacy route type validation failure');
+    }
+    expect(result.error).toEqual({ code: 'invalid_transport_type', field: 'type' });
+  });
+
+  it('rejects unsupported sub-route transport types', () => {
+    const result = validateAndNormalizeCompositeRoute({
+      from: 'A',
+      to: 'C',
+      transportType: 'train',
+      subRoutes: [
+        { from: 'A', to: 'B', transportType: 'train' },
+        { from: 'B', to: 'C', transportType: { label: 'sidecar' } }
+      ]
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected invalid sub-route transport type validation failure');
+    }
+    expect(result.error).toEqual({
+      code: 'invalid_transport_type',
+      field: 'transportType',
+      segmentNumber: 2
+    });
+  });
 });

--- a/src/app/__tests__/lib/compositeRouteValidation.test.ts
+++ b/src/app/__tests__/lib/compositeRouteValidation.test.ts
@@ -149,6 +149,21 @@ describe('validateAndNormalizeCompositeRoute', () => {
     expect(result.error).toEqual({ code: 'invalid_transport_type', field: 'transportType' });
   });
 
+  it('rejects unsupported legacy route types even when transportType is valid', () => {
+    const result = validateAndNormalizeCompositeRoute({
+      from: 'A',
+      to: 'B',
+      transportType: 'train',
+      type: 'sidecar'
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      throw new Error('Expected invalid legacy route type validation failure');
+    }
+    expect(result.error).toEqual({ code: 'invalid_transport_type', field: 'type' });
+  });
+
   it('rejects unsupported legacy top-level route types', () => {
     const result = validateAndNormalizeCompositeRoute({
       from: 'A',

--- a/src/app/__tests__/lib/routeUtils.test.ts
+++ b/src/app/__tests__/lib/routeUtils.test.ts
@@ -1,0 +1,36 @@
+import {
+  getCompositeTransportType,
+  getTransportationLabel,
+  getTransportIcon,
+  normalizeTransportationType
+} from '@/app/lib/routeUtils';
+
+describe('routeUtils transport type normalization', () => {
+  it('normalizes unsupported transport types to other', () => {
+    expect(normalizeTransportationType('sidecar')).toBe('other');
+    expect(normalizeTransportationType(null)).toBe('other');
+  });
+
+  it('allows callers to provide a supported fallback', () => {
+    expect(normalizeTransportationType('sidecar', 'train')).toBe('train');
+  });
+
+  it('falls back for labels and icons without throwing', () => {
+    expect(getTransportationLabel('sidecar')).toBe('Other');
+    expect(getTransportIcon('sidecar')).toBe(getTransportIcon('other'));
+  });
+
+  it('ignores invalid segment types when resolving composite transport type', () => {
+    expect(getCompositeTransportType([
+      { transportType: 'train' },
+      { transportType: 'sidecar' }
+    ])).toBe('train');
+  });
+
+  it('uses the caller fallback when every segment type is invalid', () => {
+    expect(getCompositeTransportType([
+      { transportType: 'sidecar' },
+      { type: { label: 'wagon' } }
+    ], 'plane')).toBe('plane');
+  });
+});

--- a/src/app/__tests__/unit/mapRouteTransform.test.ts
+++ b/src/app/__tests__/unit/mapRouteTransform.test.ts
@@ -62,6 +62,26 @@ describe('toMapRouteSegment', () => {
     expect(defaultMapped.fromCoords).toEqual([0, 0]);
     expect(defaultMapped.toCoords).toEqual([0, 0]);
   });
+
+  it('normalizes invalid route and segment transport types to other', () => {
+    const mapped = toMapRouteSegment({
+      id: 'route-invalid-type',
+      from: 'A',
+      to: 'B',
+      transportType: 'sidecar',
+      subRoutes: [
+        {
+          id: 'segment-invalid-type',
+          from: 'A',
+          to: 'B',
+          type: 'wagon'
+        }
+      ]
+    } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    expect(mapped.transportType).toBe('other');
+    expect(mapped.subRoutes?.[0].transportType).toBe('other');
+  });
 });
 
 describe('normalizeMapTravelData', () => {

--- a/src/app/admin/components/RouteDisplay.tsx
+++ b/src/app/admin/components/RouteDisplay.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import { TravelRoute } from '@/app/types';
-import { transportationLabels, getTransportIcon, getMultiSegmentEmoji, getMultiSegmentAriaLabel, getCompositeTransportType } from '@/app/lib/routeUtils';
+import {
+  getTransportationLabel,
+  getTransportIcon,
+  getMultiSegmentEmoji,
+  getMultiSegmentAriaLabel,
+  getCompositeTransportType,
+  normalizeTransportationType
+} from '@/app/lib/routeUtils';
 import { formatUtcDate } from '@/app/lib/dateUtils';
 
 interface RouteDisplayProps {
@@ -32,20 +39,21 @@ export default function RouteDisplay({
   };
 
   const hasSubRoutes = (route.subRoutes?.length || 0) > 0;
+  const routeTransportType = normalizeTransportationType(route.transportType);
   const compositeType = hasSubRoutes && route.subRoutes
-    ? getCompositeTransportType(route.subRoutes, route.transportType)
-    : route.transportType;
+    ? getCompositeTransportType(route.subRoutes, routeTransportType)
+    : routeTransportType;
   const hasManualSegments = route.subRoutes?.some(segment => segment.useManualRoutePoints) || false;
 
   // Get the emoji to display (single for regular routes, concatenated for multimodal)
   const displayEmoji = hasSubRoutes && route.subRoutes
     ? getMultiSegmentEmoji(route.subRoutes)
-    : getTransportIcon(route.transportType);
+    : getTransportIcon(routeTransportType);
 
   // Get accessibility label for screen readers
   const ariaLabel = hasSubRoutes && route.subRoutes
     ? getMultiSegmentAriaLabel(route.subRoutes.length, compositeType)
-    : transportationLabels[route.transportType];
+    : getTransportationLabel(routeTransportType);
 
   return (
     <div className="border border-gray-200 dark:border-gray-600 rounded-lg p-4 bg-white dark:bg-gray-800 hover:shadow-md transition-shadow">
@@ -60,9 +68,9 @@ export default function RouteDisplay({
           </div>
           <div className="text-sm text-gray-600 dark:text-gray-400 mt-1">
             {hasSubRoutes ? (
-              <span>{transportationLabels[compositeType]}</span>
+              <span>{getTransportationLabel(compositeType)}</span>
             ) : (
-              <span>{transportationLabels[route.transportType]}</span>
+              <span>{getTransportationLabel(routeTransportType)}</span>
             )}
             <span className="mx-2">•</span>
             <span>{formatDate(route.date)}</span>

--- a/src/app/api/travel-data/route.ts
+++ b/src/app/api/travel-data/route.ts
@@ -10,6 +10,7 @@ import {
   MAX_ROUTE_POINTS_PER_UPDATE,
   validateRoutePoints
 } from '@/app/lib/routePointValidation';
+import { normalizeTransportationType } from '@/app/lib/routeUtils';
 import type { TravelData } from '@/app/types';
 import { parseDateAsLocalDay } from '@/app/lib/localDateUtils';
 
@@ -32,6 +33,25 @@ type RoutePayload = RouteSegmentPayload & {
   id: string;
   subRoutes?: RouteSegmentPayload[];
 };
+
+const normalizeStoredRouteTransportFields = (route: RoutePayload): RoutePayload => ({
+  ...route,
+  ...(route.transportType !== undefined && {
+    transportType: normalizeTransportationType(route.transportType)
+  }),
+  ...(route.type !== undefined && {
+    type: normalizeTransportationType(route.type)
+  }),
+  subRoutes: route.subRoutes?.map((segment) => ({
+    ...segment,
+    ...(segment.transportType !== undefined && {
+      transportType: normalizeTransportationType(segment.transportType)
+    }),
+    ...(segment.type !== undefined && {
+      type: normalizeTransportationType(segment.type)
+    })
+  }))
+});
 
 const validateSubmittedRoutePoints = (
   routes?: Array<Partial<RoutePayload> & { id?: string }>,
@@ -397,7 +417,8 @@ export async function PATCH(request: NextRequest) {
         endDate: parseDateAsLocalDay(unifiedData.endDate) ?? new Date(),
         instagramUsername: unifiedData.travelData?.instagramUsername,
         locations: unifiedData.travelData?.locations || [],
-        routes: (unifiedData.travelData?.routes || []) as unknown as TravelData['routes']
+        routes: ((unifiedData.travelData?.routes || []) as unknown as RoutePayload[])
+          .map(normalizeStoredRouteTransportFields) as unknown as TravelData['routes']
       } as TravelData;
 
       // Defensive merge: apply only explicit add/update/remove operations from the delta.

--- a/src/app/api/travel-data/route.ts
+++ b/src/app/api/travel-data/route.ts
@@ -21,6 +21,8 @@ const SAFE_TRIP_ID_PATTERN = /^[A-Za-z0-9]+$/;
 type RouteSegmentPayload = {
   from: string;
   to: string;
+  type?: unknown;
+  transportType?: unknown;
   fromCoords?: [number, number];
   toCoords?: [number, number];
   routePoints?: [number, number][];
@@ -100,6 +102,12 @@ const normalizeCompositeRoutes = (
           error: validation.error.segmentNumber
             ? `Route ${route.id} sub-route ${validation.error.segmentNumber} ${validation.error.field} must be a non-empty string`
             : `Route ${route.id} ${validation.error.field} must be a non-empty string`
+        };
+      case 'invalid_transport_type':
+        return {
+          error: validation.error.segmentNumber
+            ? `Route ${route.id} sub-route ${validation.error.segmentNumber} ${validation.error.field} must be a supported transportation type`
+            : `Route ${route.id} ${validation.error.field} must be a supported transportation type`
         };
       case 'from_mismatch':
         return { error: `Route ${route.id} from does not match sub-route start` };

--- a/src/app/lib/compositeRouteValidation.ts
+++ b/src/app/lib/compositeRouteValidation.ts
@@ -54,12 +54,15 @@ const isSameCoords = (left?: [number, number], right?: [number, number]) => {
 };
 
 const getInvalidTransportField = (segment: RouteSegmentLike): 'type' | 'transportType' | null => {
-  if (segment.transportType !== undefined && !isTransportationType(segment.transportType)) {
-    return 'transportType';
-  }
+  const fields: Array<['transportType' | 'type', unknown]> = [
+    ['transportType', segment.transportType],
+    ['type', segment.type]
+  ];
 
-  if (segment.type !== undefined && !isTransportationType(segment.type)) {
-    return 'type';
+  for (const [field, value] of fields) {
+    if (value !== undefined && !isTransportationType(value)) {
+      return field;
+    }
   }
 
   return null;

--- a/src/app/lib/compositeRouteValidation.ts
+++ b/src/app/lib/compositeRouteValidation.ts
@@ -1,6 +1,10 @@
+import { isTransportationType } from '@/app/lib/routeUtils';
+
 type RouteSegmentLike = {
   from?: unknown;
   to?: unknown;
+  type?: unknown;
+  transportType?: unknown;
   fromCoords?: [number, number];
   toCoords?: [number, number];
   distanceOverride?: number;
@@ -13,6 +17,7 @@ export type CompositeRouteLike = RouteSegmentLike & {
 
 export type CompositeRouteValidationError =
   | { code: 'invalid_route_name'; field: 'from' | 'to'; segmentNumber?: number }
+  | { code: 'invalid_transport_type'; field: 'type' | 'transportType'; segmentNumber?: number }
   | { code: 'from_mismatch' }
   | { code: 'to_mismatch' }
   | { code: 'from_coords_mismatch' }
@@ -48,6 +53,18 @@ const isSameCoords = (left?: [number, number], right?: [number, number]) => {
   return Math.abs(left[0] - right[0]) < COORD_EPSILON && Math.abs(left[1] - right[1]) < COORD_EPSILON;
 };
 
+const getInvalidTransportField = (segment: RouteSegmentLike): 'type' | 'transportType' | null => {
+  if (segment.transportType !== undefined && !isTransportationType(segment.transportType)) {
+    return 'transportType';
+  }
+
+  if (segment.type !== undefined && !isTransportationType(segment.type)) {
+    return 'type';
+  }
+
+  return null;
+};
+
 const findDisconnectedSegmentNumber = (subRoutes: RouteSegmentLike[]): number | null => {
   for (let index = 1; index < subRoutes.length; index += 1) {
     const previous = subRoutes[index - 1];
@@ -79,6 +96,11 @@ export const validateAndNormalizeCompositeRoute = (route: CompositeRouteLike): C
     return { ok: false, error: { code: 'invalid_route_name', field: 'to' } };
   }
 
+  const invalidRouteTransportField = getInvalidTransportField(route);
+  if (invalidRouteTransportField) {
+    return { ok: false, error: { code: 'invalid_transport_type', field: invalidRouteTransportField } };
+  }
+
   if (!subRoutes?.length) {
     return { ok: true, normalizedRoute: route };
   }
@@ -91,6 +113,18 @@ export const validateAndNormalizeCompositeRoute = (route: CompositeRouteLike): C
 
     if (!isValidOptionalLocationName(segment.to)) {
       return { ok: false, error: { code: 'invalid_route_name', field: 'to', segmentNumber: index + 1 } };
+    }
+
+    const invalidSegmentTransportField = getInvalidTransportField(segment);
+    if (invalidSegmentTransportField) {
+      return {
+        ok: false,
+        error: {
+          code: 'invalid_transport_type',
+          field: invalidSegmentTransportField,
+          segmentNumber: index + 1
+        }
+      };
     }
   }
 

--- a/src/app/lib/mapRouteTransform.ts
+++ b/src/app/lib/mapRouteTransform.ts
@@ -4,6 +4,7 @@ import {
   type MapTravelData,
   type MapTravelLocation
 } from '@/app/types';
+import { normalizeTransportationType } from '@/app/lib/routeUtils';
 
 type RouteLike = {
   id: string;
@@ -32,7 +33,8 @@ const resolveCoords = (
   legacy?: [number, number]
 ): [number, number] => primary || legacy || [0, 0];
 
-const resolveTransportType = (route: RouteLike): string => route.transportType || route.type || 'other';
+const resolveTransportType = (route: RouteLike): string =>
+  normalizeTransportationType(route.transportType || route.type);
 
 const resolveDate = (route: RouteLike): string => {
   const value = route.date || route.departureTime;

--- a/src/app/lib/routePreloader.ts
+++ b/src/app/lib/routePreloader.ts
@@ -1,4 +1,4 @@
-import { generateRoutePoints } from './routeUtils';
+import { generateRoutePoints, normalizeTransportationType } from './routeUtils';
 import { Transportation } from '@/app/types';
 
 // Preload routes for a journey to populate the cache
@@ -36,7 +36,7 @@ export const preloadRoutes = async (routes: Array<{
     try {
       const transportation: Transportation = {
         id: route.id || 'route',
-        type: route.transportType as Transportation['type'],
+        type: normalizeTransportationType(route.transportType),
         from: route.from,
         to: route.to,
         fromCoordinates: route.fromCoords,

--- a/src/app/lib/routeUtils.ts
+++ b/src/app/lib/routeUtils.ts
@@ -142,7 +142,7 @@ export const getTransportIcon = (type: unknown): string => {
     multimodal: '🔀',
     other: '🚙'
   };
-  return icons[normalizeTransportationType(type)] || '🚙';
+  return icons[normalizeTransportationType(type)];
 };
 
 // Get emoji for multimodal routes (concatenated from segment emojis)

--- a/src/app/lib/routeUtils.ts
+++ b/src/app/lib/routeUtils.ts
@@ -99,8 +99,8 @@ export const transportationColors = Object.fromEntries(
 );
 
 // Get route style for a transportation type
-export const getRouteStyle = (type: Transportation['type']) => {
-  const config = transportationConfig[type] || transportationConfig.other;
+export const getRouteStyle = (type: unknown) => {
+  const config = transportationConfig[normalizeTransportationType(type)] || transportationConfig.other;
   return {
     color: config.color,
     weight: config.weight,
@@ -115,8 +115,19 @@ export const transportationLabels = Object.fromEntries(
   Object.entries(transportationConfig).map(([key, config]) => [key, config.description])
 );
 
+export const isTransportationType = (value: unknown): value is Transportation['type'] =>
+  typeof value === 'string' && Object.prototype.hasOwnProperty.call(transportationConfig, value);
+
+export const normalizeTransportationType = (
+  value: unknown,
+  fallback: Transportation['type'] = 'other'
+): Transportation['type'] => isTransportationType(value) ? value : fallback;
+
+export const getTransportationLabel = (value: unknown): string =>
+  transportationLabels[normalizeTransportationType(value)];
+
 // Get emoji icon for a transport type
-export const getTransportIcon = (type: Transportation['type']): string => {
+export const getTransportIcon = (type: unknown): string => {
   const icons: Record<Transportation['type'], string> = {
     plane: '✈️',
     car: '🚗',
@@ -131,25 +142,25 @@ export const getTransportIcon = (type: Transportation['type']): string => {
     multimodal: '🔀',
     other: '🚙'
   };
-  return icons[type] || '🚙';
+  return icons[normalizeTransportationType(type)] || '🚙';
 };
 
 // Get emoji for multimodal routes (concatenated from segment emojis)
-export const getMultiSegmentEmoji = <T extends { transportType?: Transportation['type']; type?: Transportation['type'] }>(
+export const getMultiSegmentEmoji = <T extends { transportType?: unknown; type?: unknown }>(
   segments: T[]
 ): string => {
   return segments.map(segment => getTransportIcon(segment.transportType || segment.type || 'other')).join('');
 };
 
 // Resolve a composite transport type for multi-segment routes
-export const getCompositeTransportType = <T extends { transportType?: Transportation['type']; type?: Transportation['type'] }>(
+export const getCompositeTransportType = <T extends { transportType?: unknown; type?: unknown }>(
   segments: T[],
   fallback: Transportation['type'] = 'other'
 ): Transportation['type'] => {
   const types = new Set(
     segments
       .map(segment => segment.transportType || segment.type)
-      .filter((type): type is Transportation['type'] => Boolean(type))
+      .filter(isTransportationType)
   );
 
   if (types.size === 0) return fallback;

--- a/src/app/lib/routeUtils.ts
+++ b/src/app/lib/routeUtils.ts
@@ -149,7 +149,7 @@ export const getTransportIcon = (type: unknown): string => {
 export const getMultiSegmentEmoji = <T extends { transportType?: unknown; type?: unknown }>(
   segments: T[]
 ): string => {
-  return segments.map(segment => getTransportIcon(segment.transportType || segment.type || 'other')).join('');
+  return segments.map(segment => getTransportIcon(segment.transportType || segment.type)).join('');
 };
 
 // Resolve a composite transport type for multi-segment routes


### PR DESCRIPTION
## Summary
- reject unsupported route and sub-route transport types at the travel-data write boundary
- normalize transport types before route display, map transforms, and route preloading so stale malformed data falls back safely
- add focused tests for validation and render-transform fallback behavior

## Verification
- bun run test:unit -- src/app/__tests__/lib/compositeRouteValidation.test.ts src/app/__tests__/lib/routeUtils.test.ts src/app/__tests__/unit/mapRouteTransform.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint src/app/lib/routeUtils.ts src/app/lib/compositeRouteValidation.ts src/app/api/travel-data/route.ts src/app/admin/components/RouteDisplay.tsx src/app/lib/routePreloader.ts src/app/lib/mapRouteTransform.ts src/app/__tests__/lib/compositeRouteValidation.test.ts src/app/__tests__/lib/routeUtils.test.ts src/app/__tests__/unit/mapRouteTransform.test.ts --max-warnings=0
- bun run build