### PR TITLE
Gate OSRM proxy to admin hosts

### DIFF
--- a/src/app/__tests__/api/osrm-routing-validation.test.ts
+++ b/src/app/__tests__/api/osrm-routing-validation.test.ts
@@ -7,11 +7,28 @@ import { NextRequest } from 'next/server';
 import { GET } from '@/app/api/routing/osrm/route';
 
 const buildRequest = (query: string): NextRequest =>
-  new NextRequest(`http://localhost/api/routing/osrm?${query}`);
+  new NextRequest(`http://localhost/api/routing/osrm?${query}`, {
+    headers: { host: 'localhost' }
+  });
 
 describe('OSRM routing proxy validation', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  it('rejects requests outside the admin domain before proxying upstream', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    const response = await GET(
+      new NextRequest(
+        'https://public.example.test/api/routing/osrm?profile=car&fromLat=51.5&fromLng=-0.1&toLat=48.8&toLng=2.3',
+        { headers: { host: 'public.example.test' } }
+      )
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: 'Admin domain required' });
+    expect(response.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it('rejects profiles outside the server allowlist', async () => {

--- a/src/app/__tests__/api/osrm-routing-validation.test.ts
+++ b/src/app/__tests__/api/osrm-routing-validation.test.ts
@@ -12,8 +12,15 @@ const buildRequest = (query: string): NextRequest =>
   });
 
 describe('OSRM routing proxy validation', () => {
+  const originalAdminDomain = process.env.ADMIN_DOMAIN;
+
   afterEach(() => {
     jest.restoreAllMocks();
+    if (originalAdminDomain === undefined) {
+      delete process.env.ADMIN_DOMAIN;
+    } else {
+      process.env.ADMIN_DOMAIN = originalAdminDomain;
+    }
   });
 
   it('rejects requests outside the admin domain before proxying upstream', async () => {
@@ -29,6 +36,53 @@ describe('OSRM routing proxy validation', () => {
     await expect(response.json()).resolves.toEqual({ error: 'Admin domain required' });
     expect(response.status).toBe(403);
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not trust forwarded admin hosts from public hosts', async () => {
+    process.env.ADMIN_DOMAIN = 'admin.example.test';
+    const fetchSpy = jest.spyOn(global, 'fetch');
+
+    const response = await GET(
+      new NextRequest(
+        'https://public.example.test/api/routing/osrm?profile=car&fromLat=51.5&fromLng=-0.1&toLat=48.8&toLng=2.3',
+        {
+          headers: {
+            host: 'public.example.test',
+            'x-forwarded-host': 'admin.example.test'
+          }
+        }
+      )
+    );
+
+    await expect(response.json()).resolves.toEqual({ error: 'Admin domain required' });
+    expect(response.status).toBe(403);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts forwarded admin hosts only from local proxy hops', async () => {
+    process.env.ADMIN_DOMAIN = 'admin.example.test';
+    const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ routes: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const response = await GET(
+      new NextRequest(
+        'http://127.0.0.1:3000/api/routing/osrm?profile=car&fromLat=51.5&fromLng=-0.1&toLat=48.8&toLng=2.3',
+        {
+          headers: {
+            host: '127.0.0.1:3000',
+            'x-forwarded-host': 'admin.example.test'
+          }
+        }
+      )
+    );
+
+    await expect(response.json()).resolves.toEqual({ routes: [] });
+    expect(response.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it('rejects profiles outside the server allowlist', async () => {

--- a/src/app/api/routing/osrm/route.ts
+++ b/src/app/api/routing/osrm/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { isAdminHost } from '@/app/lib/server-domains';
 
 type OsrmProfile = 'car' | 'bike' | 'foot';
 
@@ -41,6 +42,10 @@ const getOsrmBaseUrl = (): string => {
 };
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
+  if (!isAdminHost(request.headers.get('host'))) {
+    return NextResponse.json({ error: 'Admin domain required' }, { status: 403 });
+  }
+
   const sp = request.nextUrl.searchParams;
   const rawProfile = sp.get('profile');
   const fromLat = parseFinite(sp.get('fromLat'));

--- a/src/app/api/routing/osrm/route.ts
+++ b/src/app/api/routing/osrm/route.ts
@@ -41,8 +41,37 @@ const getOsrmBaseUrl = (): string => {
   return DEFAULT_OSRM_BASE_URL;
 };
 
+const normalizeHostForInternalCheck = (host: string | null): string => {
+  const normalized = host?.trim().toLowerCase().replace(/\.$/, '') ?? '';
+  const ipv6Match = normalized.match(/^\[([^\]]+)\](?::\d+)?$/);
+  if (ipv6Match) {
+    return ipv6Match[1];
+  }
+
+  return normalized.replace(/:\d+$/, '');
+};
+
+const isLocalProxyHost = (host: string | null): boolean => {
+  const hostname = normalizeHostForInternalCheck(host);
+  return hostname === 'localhost' || hostname === '::1' || hostname === '127.0.0.1';
+};
+
+const getForwardedHost = (request: NextRequest): string | null => {
+  const forwardedHost = request.headers.get('x-forwarded-host');
+  return forwardedHost?.split(',')[0]?.trim() || null;
+};
+
+const isAdminOsrmRequest = (request: NextRequest): boolean => {
+  const host = request.headers.get('host');
+  if (isAdminHost(host)) {
+    return true;
+  }
+
+  return isLocalProxyHost(host) && isAdminHost(getForwardedHost(request));
+};
+
 export async function GET(request: NextRequest): Promise<NextResponse> {
-  if (!isAdminHost(request.headers.get('host'))) {
+  if (!isAdminOsrmRequest(request)) {
     return NextResponse.json({ error: 'Admin domain required' }, { status: 403 });
   }
 


### PR DESCRIPTION
## Summary
- require an admin host before the OSRM proxy route forwards to OSRM upstream
- keep localhost allowed in non-production via the existing admin-host helper
- add regression coverage proving public-host requests return 403 before fetch

## Verification
- bun run test:unit -- src/app/__tests__/api/osrm-routing-validation.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint src/app/api/routing/osrm/route.ts src/app/__tests__/api/osrm-routing-validation.test.ts --max-warnings=0
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OSRM routing endpoint now includes host validation; requests from non-admin domains receive a 403 error.

* **Tests**
  * Added validation tests for OSRM routing endpoint domain restrictions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->