### PR TITLE
Normalize distance summary route types

### DIFF
--- a/src/app/admin/edit/[tripId]/components/DistanceSummary.tsx
+++ b/src/app/admin/edit/[tripId]/components/DistanceSummary.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import { TravelRoute, TransportationType } from '@/app/types';
-import { getTransportationLabel, normalizeTransportationType, transportationConfig } from '@/app/lib/routeUtils';
+import { normalizeTransportationType, transportationConfig } from '@/app/lib/routeUtils';
 import { calculateDistance } from '@/app/services/geocoding';
 import { parseDateAsLocalDay } from '@/app/lib/localDateUtils';
 
@@ -186,7 +186,7 @@ export default function DistanceSummary({ routes }: DistanceSummaryProps) {
           type,
           distance: data.distance,
           count: data.count,
-          label: getTransportationLabel(type),
+          label: transportationConfig[type].description,
           color: transportationConfig[type].color,
         }))
         .sort((a, b) => b.distance - a.distance);

--- a/src/app/admin/edit/[tripId]/components/DistanceSummary.tsx
+++ b/src/app/admin/edit/[tripId]/components/DistanceSummary.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import { TravelRoute, TransportationType } from '@/app/types';
-import { transportationConfig } from '@/app/lib/routeUtils';
+import { getTransportationLabel, normalizeTransportationType, transportationConfig } from '@/app/lib/routeUtils';
 import { calculateDistance } from '@/app/services/geocoding';
 import { parseDateAsLocalDay } from '@/app/lib/localDateUtils';
 
@@ -122,7 +122,7 @@ export default function DistanceSummary({ routes }: DistanceSummaryProps) {
           const distance = getSegmentDistance(subRoute);
           if (distance === 0) return;
 
-          const type = subRoute.transportType;
+          const type = normalizeTransportationType(subRoute.transportType);
           const existing = byType.get(type) || { distance: 0, count: 0 };
           byType.set(type, {
             distance: existing.distance + distance,
@@ -153,7 +153,7 @@ export default function DistanceSummary({ routes }: DistanceSummaryProps) {
       } else {
         // For simple routes, use the route's transport type
         const routeDistance = getSegmentDistance(route);
-        const type = route.transportType;
+        const type = normalizeTransportationType(route.transportType);
         const existing = byType.get(type) || { distance: 0, count: 0 };
         byType.set(type, {
           distance: existing.distance + routeDistance,
@@ -186,8 +186,8 @@ export default function DistanceSummary({ routes }: DistanceSummaryProps) {
           type,
           distance: data.distance,
           count: data.count,
-          label: transportationConfig[type]?.description || type,
-          color: transportationConfig[type]?.color || '#607D8B',
+          label: getTransportationLabel(type),
+          color: transportationConfig[type].color,
         }))
         .sort((a, b) => b.distance - a.distance);
     };

--- a/src/app/admin/edit/[tripId]/components/__tests__/DistanceSummary.test.tsx
+++ b/src/app/admin/edit/[tripId]/components/__tests__/DistanceSummary.test.tsx
@@ -88,6 +88,22 @@ describe('DistanceSummary', () => {
       expect(screen.getByText(/Total distance across 1 route/)).toBeInTheDocument();
     });
 
+    it('normalizes malformed route transport types before rendering breakdowns', () => {
+      const malformedTypeRoute = {
+        ...mockRoute,
+        transportType: 'sidecar',
+        routePoints: [
+          [40.7128, -74.0060],
+          [51.5074, -0.1278]
+        ]
+      } as unknown as TravelRoute;
+
+      render(<DistanceSummary routes={[malformedTypeRoute]} />);
+
+      expect(screen.getAllByText('Other').length).toBeGreaterThan(0);
+      expect(screen.getByText(/Total distance across 1 route/)).toBeInTheDocument();
+    });
+
     it('uses distance override when provided', () => {
       const routeWithOverride: TravelRoute = {
         ...mockRoute,
@@ -229,6 +245,27 @@ describe('DistanceSummary', () => {
 
       render(<DistanceSummary routes={[routeMixed]} />);
 
+      expect(screen.getByText(/Total distance across 1 route/)).toBeInTheDocument();
+    });
+
+    it('normalizes malformed sub-route transport types before rendering breakdowns', () => {
+      const malformedSubRoute = {
+        ...routeWithSubRoutes,
+        subRoutes: [
+          {
+            ...routeWithSubRoutes.subRoutes![0],
+            transportType: { label: 'sidecar' },
+            routePoints: [
+              [40.7128, -74.0060],
+              [51.5074, -0.1278]
+            ]
+          }
+        ]
+      } as unknown as TravelRoute;
+
+      render(<DistanceSummary routes={[malformedSubRoute]} />);
+
+      expect(screen.getAllByText('Other').length).toBeGreaterThan(0);
       expect(screen.getByText(/Total distance across 1 route/)).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
- normalize route and sub-route transport types before DistanceSummary aggregates by type
- render malformed/stale stored route types as Other instead of indexing config with invalid values
- add regression coverage for malformed simple-route and sub-route transport types

## Verification
- bun run test:unit -- --runTestsByPath 'src/app/admin/edit/[tripId]/components/__tests__/DistanceSummary.test.tsx' --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint 'src/app/admin/edit/[tripId]/components/DistanceSummary.tsx' 'src/app/admin/edit/[tripId]/components/__tests__/DistanceSummary.test.tsx' --max-warnings=0
- bun run build