### PR TITLE
Bound GeoJSON route imports

### DIFF
--- a/src/app/__tests__/lib/geoJsonRouteImport.test.ts
+++ b/src/app/__tests__/lib/geoJsonRouteImport.test.ts
@@ -1,0 +1,62 @@
+import {
+  MAX_GEOJSON_ROUTE_IMPORT_BYTES,
+  parseGeoJsonRouteImport,
+  validateGeoJsonRouteImportFile
+} from '@/app/lib/geoJsonRouteImport';
+import { MAX_ROUTE_POINTS_PER_ROUTE } from '@/app/lib/routePointValidation';
+
+describe('geoJsonRouteImport', () => {
+  it('extracts and converts LineString coordinates from GeoJSON', () => {
+    const points = parseGeoJsonRouteImport(JSON.stringify({
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [4.3517, 50.8503],
+          [2.3522, 48.8566]
+        ]
+      }
+    }));
+
+    expect(points).toEqual([
+      [50.8503, 4.3517],
+      [48.8566, 2.3522]
+    ]);
+  });
+
+  it('rejects files above the import byte limit before reading them', () => {
+    expect(() => validateGeoJsonRouteImportFile({
+      name: 'huge.geojson',
+      size: MAX_GEOJSON_ROUTE_IMPORT_BYTES + 1
+    })).toThrow('huge.geojson is too large');
+  });
+
+  it('rejects routes above the route point limit', () => {
+    const coordinates = Array.from(
+      { length: MAX_ROUTE_POINTS_PER_ROUTE + 1 },
+      (_, index) => [4 + index / 1000000, 50 + index / 1000000]
+    );
+
+    expect(() => parseGeoJsonRouteImport(JSON.stringify({
+      type: 'LineString',
+      coordinates
+    }))).toThrow(`GeoJSON route cannot contain more than ${MAX_ROUTE_POINTS_PER_ROUTE} points`);
+  });
+
+  it('rejects route points outside valid latitude and longitude ranges', () => {
+    expect(() => parseGeoJsonRouteImport(JSON.stringify({
+      type: 'LineString',
+      coordinates: [
+        [4.3517, 50.8503],
+        [2.3522, 91]
+      ]
+    }))).toThrow('GeoJSON route[1] must be a valid [latitude, longitude] pair');
+  });
+
+  it('rejects GeoJSON without a LineString geometry', () => {
+    expect(() => parseGeoJsonRouteImport(JSON.stringify({
+      type: 'Point',
+      coordinates: [4.3517, 50.8503]
+    }))).toThrow('No LineString coordinates found in GeoJSON');
+  });
+});

--- a/src/app/admin/components/RouteInlineEditor.tsx
+++ b/src/app/admin/components/RouteInlineEditor.tsx
@@ -8,6 +8,7 @@ import { coerceValidDate } from '@/app/lib/dateUtils';
 import { parseDistanceOverride } from '@/app/lib/distanceOverride';
 import { generateId } from '@/app/lib/costUtils';
 import { formatLocalDateLabel, getTodayLocalDay, parseDateAsLocalDay } from '@/app/lib/localDateUtils';
+import { parseGeoJsonRouteImport, validateGeoJsonRouteImportFile } from '@/app/lib/geoJsonRouteImport';
 import CostTrackingLinksManager from './CostTrackingLinksManager';
 import AriaSelect from './AriaSelect';
 import AriaComboBox from './AriaComboBox';
@@ -60,6 +61,10 @@ export default function RouteInlineEditor({
   const routeDateValue = useMemo(
     () => parseDateAsLocalDay(formData.date),
     [formData.date]
+  );
+  const subRouteTransportTypesKey = useMemo(
+    () => formData.subRoutes?.map(segment => segment.transportType).join('|') ?? '',
+    [formData.subRoutes]
   );
   const locationChoiceOptions = useMemo(
     () => locationOptions.map(location => ({ value: location.name, label: location.name })),
@@ -120,7 +125,7 @@ export default function RouteInlineEditor({
     });
   }, [
     formData.subRoutes?.length,
-    formData.subRoutes?.map(segment => segment.transportType).join('|')
+    subRouteTransportTypesKey
   ]);
 
   useEffect(() => {
@@ -467,76 +472,13 @@ export default function RouteInlineEditor({
     });
   };
 
-  const extractCoordinates = (geojson: unknown): [number, number][] | null => {
-    const toLatLng = (pair: unknown): [number, number] | null => {
-      if (!Array.isArray(pair) || pair.length < 2) return null;
-      const [lng, lat] = pair;
-      if (typeof lat !== 'number' || typeof lng !== 'number') return null;
-      return [lat, lng];
-    };
-
-    const pickLine = (geometry: unknown): unknown[] | null => {
-      if (!geometry || typeof geometry !== 'object') return null;
-      const geom = geometry as { type?: unknown; coordinates?: unknown };
-      if (geom.type === 'LineString' && Array.isArray(geom.coordinates)) {
-        return geom.coordinates;
-      }
-      if (
-        geom.type === 'MultiLineString' &&
-        Array.isArray(geom.coordinates) &&
-        Array.isArray((geom.coordinates as unknown[])[0])
-      ) {
-        return (geom.coordinates as unknown[])[0] as unknown[];
-      }
-      return null;
-    };
-
-    if (
-      geojson &&
-      typeof geojson === 'object' &&
-      (geojson as { type?: unknown }).type === 'FeatureCollection'
-    ) {
-      const features = (geojson as { features?: unknown }).features;
-      if (Array.isArray(features)) {
-        for (const feature of features) {
-          const geometry = (feature as { geometry?: unknown }).geometry;
-          const coords = pickLine(geometry);
-          if (coords) {
-            const normalized = coords.map(toLatLng).filter((val): val is [number, number] => Boolean(val));
-            if (normalized.length) return normalized;
-          }
-        }
-      }
-    }
-
-    if (geojson && typeof geojson === 'object' && (geojson as { type?: unknown }).type === 'Feature') {
-      const geometry = (geojson as { geometry?: unknown }).geometry;
-      const coords = pickLine(geometry);
-      if (coords) return coords.map(toLatLng).filter((val): val is [number, number] => Boolean(val));
-    }
-
-    if (geojson && typeof geojson === 'object') {
-      const type = (geojson as { type?: unknown }).type;
-      if (type === 'LineString' || type === 'MultiLineString') {
-        const coords = pickLine(geojson);
-        if (coords) return coords.map(toLatLng).filter((val): val is [number, number] => Boolean(val));
-      }
-    }
-
-    return null;
-  };
-
   const handleGeoJSONImport = async (file: File) => {
     setImportError('');
     setImportStatus('Importing...');
     try {
+      validateGeoJsonRouteImportFile(file);
       const text = await file.text();
-      const parsed = JSON.parse(text) as unknown;
-      const rawCoords = extractCoordinates(parsed);
-
-      if (!rawCoords || rawCoords.length === 0) {
-        throw new Error('No LineString coordinates found in GeoJSON');
-      }
+      const rawCoords = parseGeoJsonRouteImport(text);
 
       setFormData(prev => ({
         ...prev,
@@ -555,13 +497,9 @@ export default function RouteInlineEditor({
     setSegmentImportStatus(prev => ({ ...prev, [segmentId]: 'Importing...' }));
 
     try {
+      validateGeoJsonRouteImportFile(file);
       const text = await file.text();
-      const parsed = JSON.parse(text) as unknown;
-      const rawCoords = extractCoordinates(parsed);
-
-      if (!rawCoords || rawCoords.length === 0) {
-        throw new Error('No LineString coordinates found in GeoJSON');
-      }
+      const rawCoords = parseGeoJsonRouteImport(text);
 
       setFormData(prev => {
         const subRoutes = prev.subRoutes?.map(segment =>

--- a/src/app/lib/geoJsonRouteImport.ts
+++ b/src/app/lib/geoJsonRouteImport.ts
@@ -1,0 +1,122 @@
+import {
+  MAX_ROUTE_POINTS_PER_ROUTE,
+  RoutePoint,
+  validateRoutePoints
+} from '@/app/lib/routePointValidation';
+
+export const MAX_GEOJSON_ROUTE_IMPORT_BYTES = 20 * 1024 * 1024;
+
+type GeoJsonImportFile = Pick<File, 'name' | 'size'>;
+
+export const validateGeoJsonRouteImportFile = (file: GeoJsonImportFile): void => {
+  if (file.size > MAX_GEOJSON_ROUTE_IMPORT_BYTES) {
+    throw new Error(
+      `${file.name} is too large. GeoJSON imports are limited to ${Math.floor(MAX_GEOJSON_ROUTE_IMPORT_BYTES / (1024 * 1024))} MB.`
+    );
+  }
+};
+
+const toLatLng = (pair: unknown): RoutePoint | null => {
+  if (!Array.isArray(pair) || pair.length < 2) {
+    return null;
+  }
+
+  const [lng, lat] = pair;
+  if (typeof lat !== 'number' || typeof lng !== 'number') {
+    return null;
+  }
+
+  return [lat, lng];
+};
+
+const pickLine = (geometry: unknown): unknown[] | null => {
+  if (!geometry || typeof geometry !== 'object') {
+    return null;
+  }
+
+  const geom = geometry as { type?: unknown; coordinates?: unknown };
+  if (geom.type === 'LineString' && Array.isArray(geom.coordinates)) {
+    return geom.coordinates;
+  }
+
+  if (
+    geom.type === 'MultiLineString' &&
+    Array.isArray(geom.coordinates) &&
+    Array.isArray((geom.coordinates as unknown[])[0])
+  ) {
+    return (geom.coordinates as unknown[])[0] as unknown[];
+  }
+
+  return null;
+};
+
+const normalizeCoordinates = (coords: unknown[]): RoutePoint[] | null => {
+  if (coords.length > MAX_ROUTE_POINTS_PER_ROUTE) {
+    throw new Error(`GeoJSON route cannot contain more than ${MAX_ROUTE_POINTS_PER_ROUTE} points`);
+  }
+
+  const normalized = coords.map(toLatLng).filter((value): value is RoutePoint => Boolean(value));
+  if (!normalized.length) {
+    return null;
+  }
+
+  const validation = validateRoutePoints(normalized, 'GeoJSON route');
+  if (!validation.ok) {
+    throw new Error(validation.error);
+  }
+
+  return validation.points;
+};
+
+export const extractGeoJsonRoutePoints = (geojson: unknown): RoutePoint[] | null => {
+  if (
+    geojson &&
+    typeof geojson === 'object' &&
+    (geojson as { type?: unknown }).type === 'FeatureCollection'
+  ) {
+    const features = (geojson as { features?: unknown }).features;
+    if (Array.isArray(features)) {
+      for (const feature of features) {
+        const geometry = (feature as { geometry?: unknown }).geometry;
+        const coords = pickLine(geometry);
+        if (coords) {
+          const normalized = normalizeCoordinates(coords);
+          if (normalized) {
+            return normalized;
+          }
+        }
+      }
+    }
+  }
+
+  if (geojson && typeof geojson === 'object' && (geojson as { type?: unknown }).type === 'Feature') {
+    const geometry = (geojson as { geometry?: unknown }).geometry;
+    const coords = pickLine(geometry);
+    if (coords) {
+      return normalizeCoordinates(coords);
+    }
+  }
+
+  if (geojson && typeof geojson === 'object') {
+    const type = (geojson as { type?: unknown }).type;
+    if (type === 'LineString' || type === 'MultiLineString') {
+      const coords = pickLine(geojson);
+      if (coords) {
+        return normalizeCoordinates(coords);
+      }
+    }
+  }
+
+  return null;
+};
+
+export const parseGeoJsonRouteImport = (text: string): RoutePoint[] => {
+  const parsed = JSON.parse(text) as unknown;
+  const routePoints = extractGeoJsonRoutePoints(parsed);
+
+  if (!routePoints || routePoints.length === 0) {
+    throw new Error('No LineString coordinates found in GeoJSON');
+  }
+
+  return routePoints;
+};


### PR DESCRIPTION
## Summary
- move admin GeoJSON route import parsing into a shared bounded utility
- reject oversized GeoJSON files before reading them into memory
- validate imported route points against the existing route point bounds before writing them to editor state

## Security
- addresses Codex finding c6984d4366608191bd7d7ff1b6f40a65 by reducing the public/admin attack surface for huge GeoJSON route imports without lowering the existing large-route persistence limit

## Verification
- bun run test:unit -- src/app/__tests__/lib/geoJsonRouteImport.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint src/app/lib/geoJsonRouteImport.ts src/app/admin/components/RouteInlineEditor.tsx src/app/__tests__/lib/geoJsonRouteImport.test.ts --max-warnings=0
- bun run build