### PR TITLE
Sanitize public post URLs

### DIFF
--- a/src/app/__tests__/lib/serverPrivacyUtils.test.ts
+++ b/src/app/__tests__/lib/serverPrivacyUtils.test.ts
@@ -97,6 +97,59 @@ describe('server privacy utilities', () => {
     expect(result.accommodations?.[0]?.costTrackingLinks).toBeUndefined();
   });
 
+  it('removes unsafe post URLs from public journey periods', () => {
+    const result = filterJourneyForServer(
+      {
+        id: 'trip-1',
+        title: 'Trip',
+        startDate: new Date('2026-01-01T00:00:00.000Z'),
+        days: [
+          {
+            id: 'period-1',
+            title: 'City',
+            date: new Date('2026-01-01T00:00:00.000Z'),
+            locations: [],
+            instagramPosts: [
+              { id: 'ig-safe', url: 'https://instagram.com/p/safe', caption: 'safe' },
+              { id: 'ig-unsafe', url: 'javascript:alert(1)', caption: 'unsafe' },
+            ],
+            tikTokPosts: [
+              { id: 'tt-safe', url: 'https://example.com/tiktok', caption: 'safe' },
+              { id: 'tt-unsafe', url: 'data:text/html,<script>alert(1)</script>', caption: 'unsafe' },
+            ],
+          },
+        ],
+      },
+      'travel.example'
+    );
+
+    expect(result.days[0].instagramPosts).toEqual([
+      { id: 'ig-safe', url: 'https://instagram.com/p/safe', caption: 'safe' },
+    ]);
+    expect(result.days[0].tikTokPosts).toEqual([
+      { id: 'tt-safe', url: 'https://example.com/tiktok', caption: 'safe' },
+    ]);
+  });
+
+  it('handles null public post arrays from JSON data defensively', () => {
+    const result = filterTravelDataForServer(
+      {
+        locations: [
+          {
+            id: 'loc-1',
+            name: 'City',
+            coordinates: [50, 4],
+            date: new Date('2026-01-01T00:00:00.000Z'),
+            instagramPosts: null,
+          },
+        ],
+      } as never,
+      'travel.example'
+    );
+
+    expect(result.locations?.[0]?.instagramPosts).toBeUndefined();
+  });
+
   it('removes accommodation references and shadow flags from public locations', () => {
     const result = filterTravelDataForServer(
       {
@@ -122,6 +175,44 @@ describe('server privacy utilities', () => {
     expect(result.locations?.[0]?.isAccommodationPublic).toBeUndefined();
     expect(result.locations?.[0]?.isReadOnly).toBeUndefined();
     expect(result.locations?.[0]?.costTrackingLinks).toBeUndefined();
+  });
+
+  it('removes unsafe post URLs from public locations', () => {
+    const result = filterTravelDataForServer(
+      {
+        locations: [
+          {
+            id: 'loc-1',
+            name: 'City',
+            coordinates: [50, 4],
+            date: new Date('2026-01-01T00:00:00.000Z'),
+            instagramPosts: [
+              { id: 'ig-safe', url: 'https://instagram.com/p/safe', caption: 'safe' },
+              { id: 'ig-unsafe', url: 'javascript:alert(1)', caption: 'unsafe' },
+            ],
+            tikTokPosts: [
+              { id: 'tt-safe', url: 'http://example.com/tiktok', caption: 'safe' },
+              { id: 'tt-unsafe', url: 'data:text/html,<script>alert(1)</script>', caption: 'unsafe' },
+            ],
+            blogPosts: [
+              { id: 'blog-safe', title: 'Safe', url: 'https://example.com/blog' },
+              { id: 'blog-unsafe', title: 'Unsafe', url: 'vbscript:msgbox(1)' },
+            ],
+          },
+        ],
+      },
+      'travel.example'
+    );
+
+    expect(result.locations?.[0]?.instagramPosts).toEqual([
+      { id: 'ig-safe', url: 'https://instagram.com/p/safe', caption: 'safe' },
+    ]);
+    expect(result.locations?.[0]?.tikTokPosts).toEqual([
+      { id: 'tt-safe', url: 'http://example.com/tiktok', caption: 'safe' },
+    ]);
+    expect(result.locations?.[0]?.blogPosts).toEqual([
+      { id: 'blog-safe', title: 'Safe', url: 'https://example.com/blog' },
+    ]);
   });
 
   it('preserves accommodation expense links for admin travel data', () => {

--- a/src/app/lib/publicUrlValidation.ts
+++ b/src/app/lib/publicUrlValidation.ts
@@ -1,0 +1,20 @@
+export const isSafePublicHttpUrl = (url: unknown): url is string => {
+  if (typeof url !== 'string') {
+    return false;
+  }
+
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+export const filterSafePublicLinks = <T extends { url: string }>(links: T[] | undefined | null): T[] | undefined => {
+  if (links == null) {
+    return undefined;
+  }
+
+  return links.filter(link => isSafePublicHttpUrl(link.url));
+};

--- a/src/app/lib/serverPrivacyUtils.ts
+++ b/src/app/lib/serverPrivacyUtils.ts
@@ -1,5 +1,6 @@
 import { Accommodation, Journey, Location, Transportation, JourneyPeriod } from '@/app/types';
 import { isAdminHost } from '@/app/lib/server-domains';
+import { filterSafePublicLinks } from '@/app/lib/publicUrlValidation';
 
 interface TravelData {
   locations?: Location[];
@@ -35,6 +36,9 @@ export function filterLocationForServer(location: Location, host: string | null)
     // Remove private fields completely
     accommodationIds: undefined,
     costTrackingLinks: undefined,
+    instagramPosts: filterSafePublicLinks(location.instagramPosts),
+    tikTokPosts: filterSafePublicLinks(location.tikTokPosts),
+    blogPosts: filterSafePublicLinks(location.blogPosts),
     // Handle accommodation privacy
     accommodationData: location.isAccommodationPublic ? location.accommodationData : undefined,
     isAccommodationPublic: undefined, // Don't expose the privacy flag itself
@@ -128,6 +132,8 @@ export function filterJourneyPeriodForServer(
 
   return {
     ...period,
+    instagramPosts: filterSafePublicLinks(period.instagramPosts),
+    tikTokPosts: filterSafePublicLinks(period.tikTokPosts),
     locations: filteredLocations,
     transportation: filteredTransportation,
   };

--- a/src/app/lib/tripUpdates.ts
+++ b/src/app/lib/tripUpdates.ts
@@ -1,6 +1,7 @@
 import { formatDateRange, normalizeUtcDateToLocalDay } from './dateUtils';
 import { Location, Transportation, TripUpdate, TripUpdateLink, InstagramPost, TikTokPost, BlogPost } from '@/app/types';
 import { UnifiedTripData } from './dataMigration';
+import { isSafePublicHttpUrl } from './publicUrlValidation';
 
 type RouteLike = Transportation & { transportType?: string };
 
@@ -60,16 +61,6 @@ const isBlogPost = (post: InstagramPost | TikTokPost | BlogPost): post is BlogPo
   return 'title' in post && typeof post.title === 'string';
 };
 
-// Validate URL to prevent XSS attacks - only allow http(s) protocols
-const isValidHttpUrl = (url: string): boolean => {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-  } catch {
-    return false;
-  }
-};
-
 const addPostUpdate = (
   updates: TripUpdate[],
   location: Location,
@@ -82,7 +73,7 @@ const addPostUpdate = (
 
   // Extract links from posts, validating URLs to prevent XSS
   const links: TripUpdateLink[] = posts
-    .filter(post => isValidHttpUrl(post.url))
+    .filter(post => isSafePublicHttpUrl(post.url))
     .map(post => {
       if (isBlogPost(post)) {
         // Truncate blog titles to 80 chars for UI consistency


### PR DESCRIPTION
## Summary
- add a shared HTTP(S)-only public URL validator
- filter unsafe Instagram, TikTok, and blog post URLs at the public server privacy boundary
- reuse the same validator for generated trip update links

## Security
- addresses Codex findings 0f3b25c8dd5c8191995a838297faca4d and ac0267c89e7c819190738322b62871e6 by preventing non-HTTP(S) post URLs from reaching public map/embed link renderers

## Verification
- bun run test:unit -- src/app/__tests__/lib/serverPrivacyUtils.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint src/app/lib/publicUrlValidation.ts src/app/lib/serverPrivacyUtils.ts src/app/lib/tripUpdates.ts src/app/__tests__/lib/serverPrivacyUtils.test.ts --max-warnings=0
- bun run build