### PR TITLE
Defend route duration summaries

### DIFF
--- a/src/app/__tests__/lib/routeDurationDisplay.test.ts
+++ b/src/app/__tests__/lib/routeDurationDisplay.test.ts
@@ -1,0 +1,33 @@
+import {
+  normalizeRouteDurationDisplay,
+  summarizeSegmentDurations
+} from '@/app/lib/routeDurationDisplay';
+
+describe('routeDurationDisplay', () => {
+  it('trims string durations', () => {
+    expect(normalizeRouteDurationDisplay(' 2h 30m ')).toBe('2h 30m');
+  });
+
+  it('formats scalar malformed durations defensively', () => {
+    expect(normalizeRouteDurationDisplay(45)).toBe('45');
+    expect(normalizeRouteDurationDisplay(true)).toBe('true');
+  });
+
+  it('drops object-like malformed durations without throwing', () => {
+    expect(normalizeRouteDurationDisplay({ value: '45m' })).toBe('');
+    expect(normalizeRouteDurationDisplay(null)).toBe('');
+  });
+
+  it('summarizes segment durations while ignoring unsupported values', () => {
+    expect(summarizeSegmentDurations([
+      { duration: ' 1h ' },
+      { duration: 30 },
+      { duration: { value: 'bad' } },
+      {}
+    ])).toBe('1h + 30');
+  });
+
+  it('returns fallback text when no displayable segment durations exist', () => {
+    expect(summarizeSegmentDurations([{ duration: ' ' }, { duration: null }])).toBe('Set duration on each segment');
+  });
+});

--- a/src/app/admin/components/RouteForm.tsx
+++ b/src/app/admin/components/RouteForm.tsx
@@ -7,6 +7,7 @@ import { coerceValidDate } from '@/app/lib/dateUtils';
 import { validateAndNormalizeCompositeRoute } from '@/app/lib/compositeRouteValidation';
 import { parseDistanceOverride } from '@/app/lib/distanceOverride';
 import { getTodayLocalDay, parseDateAsLocalDay } from '@/app/lib/localDateUtils';
+import { summarizeSegmentDurations } from '@/app/lib/routeDurationDisplay';
 import CostTrackingLinksManager from './CostTrackingLinksManager';
 import AriaSelect from './AriaSelect';
 import AriaComboBox from './AriaComboBox';
@@ -94,6 +95,10 @@ export default function RouteForm({
     () => coerceValidDate(currentRoute.date),
     [currentRoute.date]
   );
+  const subRouteTransportTypesKey = useMemo(
+    () => currentRoute.subRoutes?.map(segment => segment.transportType).join('|') ?? '',
+    [currentRoute.subRoutes]
+  );
 
   const locationChoiceOptions = useMemo(
     () => locationOptions.map(location => ({ value: location.name, label: location.name })),
@@ -129,7 +134,7 @@ export default function RouteForm({
     });
   }, [
     currentRoute.subRoutes?.length,
-    currentRoute.subRoutes?.map(segment => segment.transportType).join('|'),
+    subRouteTransportTypesKey,
     setCurrentRoute
   ]);
 
@@ -140,8 +145,9 @@ export default function RouteForm({
 
   // Cleanup all debounced functions on unmount
   useEffect(() => {
+    const geocodingDebouncers = geocodingDebouncersRef.current;
     return () => {
-      Object.values(geocodingDebouncersRef.current).forEach(debouncer => debouncer.cancel());
+      Object.values(geocodingDebouncers).forEach(debouncer => debouncer.cancel());
     };
   }, []);
 
@@ -838,7 +844,7 @@ export default function RouteForm({
               Duration
             </div>
             <div className="w-full px-3 py-2 border border-gray-300 rounded-md bg-gray-100">
-              {currentRoute.subRoutes?.map(s => s.duration?.trim()).filter(Boolean).join(' + ') || 'Set duration on each segment'}
+              {summarizeSegmentDurations(currentRoute.subRoutes)}
             </div>
             <p className="text-xs text-gray-500 mt-1">Duration is derived from segments.</p>
           </div>

--- a/src/app/admin/components/RouteInlineEditor.tsx
+++ b/src/app/admin/components/RouteInlineEditor.tsx
@@ -9,6 +9,7 @@ import { parseDistanceOverride } from '@/app/lib/distanceOverride';
 import { generateId } from '@/app/lib/costUtils';
 import { formatLocalDateLabel, getTodayLocalDay, parseDateAsLocalDay } from '@/app/lib/localDateUtils';
 import { parseGeoJsonRouteImport, validateGeoJsonRouteImportFile } from '@/app/lib/geoJsonRouteImport';
+import { summarizeSegmentDurations } from '@/app/lib/routeDurationDisplay';
 import CostTrackingLinksManager from './CostTrackingLinksManager';
 import AriaSelect from './AriaSelect';
 import AriaComboBox from './AriaComboBox';
@@ -1210,7 +1211,7 @@ export default function RouteInlineEditor({
 	              Duration
 	            </div>
 	            <div className="w-full px-2 py-1 text-sm border border-gray-200 dark:border-gray-700 rounded bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
-	              {formData.subRoutes?.map(s => s.duration?.trim()).filter(Boolean).join(' + ') || 'Set duration on each segment'}
+	              {summarizeSegmentDurations(formData.subRoutes)}
 	            </div>
 	            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">Duration is derived from segments.</p>
 	          </div>

--- a/src/app/lib/routeDurationDisplay.ts
+++ b/src/app/lib/routeDurationDisplay.ts
@@ -1,0 +1,25 @@
+export const normalizeRouteDurationDisplay = (duration: unknown): string => {
+  if (duration === undefined || duration === null) {
+    return '';
+  }
+
+  if (typeof duration === 'string') {
+    return duration.trim();
+  }
+
+  if (typeof duration === 'number' || typeof duration === 'boolean') {
+    return String(duration).trim();
+  }
+
+  return '';
+};
+
+export const summarizeSegmentDurations = (
+  segments: Array<{ duration?: unknown }> | undefined
+): string => {
+  const durationParts = segments
+    ?.map(segment => normalizeRouteDurationDisplay(segment.duration))
+    .filter(Boolean);
+
+  return durationParts?.join(' + ') || 'Set duration on each segment';
+};


### PR DESCRIPTION
## Summary
- add a defensive route duration display helper for segment summaries
- use it in both route editor components instead of calling trim on unknown persisted values
- clean up existing hook dependency warnings in RouteForm while touching the file

## Security
- addresses Codex finding d9ad9d3a42d881918095f51797b4ad51 by preventing malformed persisted sub-route durations from crashing the admin editor render path

## Verification
- bun run test:unit -- src/app/__tests__/lib/routeDurationDisplay.test.ts --modulePathIgnorePatterns='<rootDir>/.worktrees' --modulePathIgnorePatterns='<rootDir>/.next'
- bunx eslint src/app/lib/routeDurationDisplay.ts src/app/admin/components/RouteInlineEditor.tsx src/app/admin/components/RouteForm.tsx src/app/__tests__/lib/routeDurationDisplay.test.ts --max-warnings=0
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced route duration display with improved handling of segment duration aggregation, better validation, and more consistent fallback messaging across the admin interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->