### PR TITLE
[codex] Harden Timeline post links

### DIFF
--- a/src/app/components/Timeline.tsx
+++ b/src/app/components/Timeline.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, type ReactNode } from 'react';
 import { format } from 'date-fns';
 import { CostTrackingData, Journey, JourneyDay, Transportation } from '@/app/types';
 import { transportationColors, getTransportIcon, getMultiSegmentEmoji, getMultiSegmentAriaLabel, getCompositeTransportType } from '@/app/lib/routeUtils';
@@ -8,6 +8,7 @@ import { ExpenseTravelLookup } from '@/app/lib/expenseTravelLookup';
 import AccommodationDisplay from '@/app/components/AccommodationDisplay';
 import TikTokIcon from '@/app/components/icons/TikTokIcon';
 import { formatCurrency } from '@/app/lib/costUtils';
+import { isSafePublicHttpUrl } from '@/app/lib/publicUrlValidation';
 
 interface TimelineProps {
   journey: Journey | null;
@@ -18,6 +19,31 @@ interface TimelineProps {
   travelLookup?: ExpenseTravelLookup | null;
   costData?: CostTrackingData | null;
 }
+
+interface SafeExternalLinkProps {
+  url: string;
+  className: string;
+  title?: string;
+  children: ReactNode;
+}
+
+const SafeExternalLink: React.FC<SafeExternalLinkProps> = ({ url, className, title, children }) => {
+  if (!isSafePublicHttpUrl(url)) {
+    return null;
+  }
+
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+      title={title}
+    >
+      {children}
+    </a>
+  );
+};
 
 const Timeline: React.FC<TimelineProps> = ({ journey, selectedDayId, onDaySelect, onAddDay, isAdminView = false, travelLookup, costData }) => {
   const [expandedDayId, setExpandedDayId] = useState<string | null>(null);
@@ -156,15 +182,13 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
                           <div className="space-y-1">
                             {location.blogPosts.map((post, index) => (
                               <div key={post.id || index}>
-                                <a
-                                  href={post.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
+                                <SafeExternalLink
+                                  url={post.url}
                                   className="text-green-600 hover:text-green-800 text-xs underline block"
                                   title={post.title}
                                 >
                                   {post.title.length > 40 ? `${post.title.substring(0, 40)}...` : post.title}
-                                </a>
+                                </SafeExternalLink>
                               </div>
                             ))}
                           </div>
@@ -178,15 +202,13 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
                           <div className="space-y-1">
                             {location.instagramPosts.map((post, index) => (
                               <div key={post.id || index}>
-                                <a
-                                  href={post.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
+                                <SafeExternalLink
+                                  url={post.url}
                                   className="text-blue-600 hover:text-blue-800 text-xs underline block"
                                   title={post.url}
                                 >
                                   View Post {location.instagramPosts!.length > 1 ? `#${index + 1}` : ''}
-                                </a>
+                                </SafeExternalLink>
                               </div>
                             ))}
                           </div>
@@ -203,15 +225,13 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
                           <div className="space-y-1">
                             {location.tikTokPosts.map((post, index) => (
                               <div key={post.id || index}>
-                                <a
-                                  href={post.url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
+                                <SafeExternalLink
+                                  url={post.url}
                                   className="text-gray-700 hover:text-gray-900 text-xs underline block"
                                   title={post.caption || post.url}
                                 >
                                   Watch Clip {location.tikTokPosts!.length > 1 ? `#${index + 1}` : ''}
-                                </a>
+                                </SafeExternalLink>
                                 {post.caption && (
                                   <p className="text-[10px] text-gray-500">{post.caption}</p>
                                 )}
@@ -254,9 +274,9 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
               <div className="space-y-2">
                 {day.instagramPosts.map(post => (
                   <div key={post.id} className="border border-gray-200 dark:border-gray-700 rounded-sm p-2">
-                    <a href={post.url} target="_blank" rel="noopener noreferrer" className="text-blue-500 dark:text-blue-400 text-sm hover:underline">
+                    <SafeExternalLink url={post.url} className="text-blue-500 dark:text-blue-400 text-sm hover:underline">
                       View Instagram Post
-                    </a>
+                    </SafeExternalLink>
                   </div>
                 ))}
               </div>
@@ -270,14 +290,12 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
               <div className="space-y-2">
                 {day.tikTokPosts.map(post => (
                   <div key={post.id} className="border border-gray-200 dark:border-gray-700 rounded-sm p-2">
-                    <a
-                      href={post.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                    <SafeExternalLink
+                      url={post.url}
                       className="text-gray-700 dark:text-gray-200 text-sm hover:underline"
                     >
                       View TikTok Post
-                    </a>
+                    </SafeExternalLink>
                     {post.caption && (
                       <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">{post.caption}</p>
                     )}

--- a/src/app/components/Timeline.tsx
+++ b/src/app/components/Timeline.tsx
@@ -45,6 +45,9 @@ const SafeExternalLink: React.FC<SafeExternalLinkProps> = ({ url, className, tit
   );
 };
 
+const safePosts = <T extends { url: string }>(posts?: T[]): T[] =>
+  (posts ?? []).filter(post => isSafePublicHttpUrl(post.url));
+
 const Timeline: React.FC<TimelineProps> = ({ journey, selectedDayId, onDaySelect, onAddDay, isAdminView = false, travelLookup, costData }) => {
   const [expandedDayId, setExpandedDayId] = useState<string | null>(null);
   
@@ -113,6 +116,8 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
   const formattedDate = format(new Date(day.date), 'MMM d, yyyy');
   const headerId = `timeline-day-${day.id}-header`;
   const panelId = `timeline-day-${day.id}-panel`;
+  const safeDayInstagramPosts = safePosts(day.instagramPosts);
+  const safeDayTikTokPosts = safePosts(day.tikTokPosts);
   
   return (
     <div 
@@ -158,7 +163,12 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
             <div className="mb-3">
               <h4 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-2">Locations</h4>
               <div className="space-y-2">
-                {day.locations.map(location => (
+                {day.locations.map(location => {
+                  const safeLocationBlogPosts = safePosts(location.blogPosts);
+                  const safeLocationInstagramPosts = safePosts(location.instagramPosts);
+                  const safeLocationTikTokPosts = safePosts(location.tikTokPosts);
+
+                  return (
                   <div key={location.id} className="flex items-start">
                     <div className="shrink-0 mt-1">
                       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-4 h-4 text-red-500">
@@ -176,11 +186,11 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
                       )}
                       
                       {/* Display Blog Posts */}
-                      {location.blogPosts && location.blogPosts.length > 0 && (
+                      {safeLocationBlogPosts.length > 0 && (
                         <div className="mt-2">
                           <div className="text-xs font-semibold text-green-700 mb-1">📝 Blog Posts:</div>
                           <div className="space-y-1">
-                            {location.blogPosts.map((post, index) => (
+                            {safeLocationBlogPosts.map((post, index) => (
                               <div key={post.id || index}>
                                 <SafeExternalLink
                                   url={post.url}
@@ -196,18 +206,18 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
                       )}
                       
                       {/* Display Instagram Posts */}
-                      {location.instagramPosts && location.instagramPosts.length > 0 && (
+                      {safeLocationInstagramPosts.length > 0 && (
                         <div className="mt-2">
                           <div className="text-xs font-semibold text-blue-700 mb-1">📸 Instagram:</div>
                           <div className="space-y-1">
-                            {location.instagramPosts.map((post, index) => (
+                            {safeLocationInstagramPosts.map((post, index) => (
                               <div key={post.id || index}>
                                 <SafeExternalLink
                                   url={post.url}
                                   className="text-blue-600 hover:text-blue-800 text-xs underline block"
                                   title={post.url}
                                 >
-                                  View Post {location.instagramPosts!.length > 1 ? `#${index + 1}` : ''}
+                                  View Post {safeLocationInstagramPosts.length > 1 ? `#${index + 1}` : ''}
                                 </SafeExternalLink>
                               </div>
                             ))}
@@ -216,21 +226,21 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
                       )}
 
                       {/* Display TikTok Posts */}
-                      {location.tikTokPosts && location.tikTokPosts.length > 0 && (
+                      {safeLocationTikTokPosts.length > 0 && (
                         <div className="mt-2">
                           <div className="text-xs font-semibold text-gray-700 mb-1 flex items-center gap-1">
                             <TikTokIcon containerClassName="w-4 h-4" iconClassName="w-2.5 h-2.5" ariaLabel="TikTok" />
                             <span>TikTok:</span>
                           </div>
                           <div className="space-y-1">
-                            {location.tikTokPosts.map((post, index) => (
+                            {safeLocationTikTokPosts.map((post, index) => (
                               <div key={post.id || index}>
                                 <SafeExternalLink
                                   url={post.url}
                                   className="text-gray-700 hover:text-gray-900 text-xs underline block"
                                   title={post.caption || post.url}
                                 >
-                                  Watch Clip {location.tikTokPosts!.length > 1 ? `#${index + 1}` : ''}
+                                  Watch Clip {safeLocationTikTokPosts.length > 1 ? `#${index + 1}` : ''}
                                 </SafeExternalLink>
                                 {post.caption && (
                                   <p className="text-[10px] text-gray-500">{post.caption}</p>
@@ -250,7 +260,8 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
                       />
                     </div>
                   </div>
-                ))}
+                  );
+                })}
               </div>
             </div>
           )}
@@ -268,11 +279,11 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
           )}
           
           {/* Instagram Posts */}
-          {day.instagramPosts && day.instagramPosts.length > 0 && (
+          {safeDayInstagramPosts.length > 0 && (
             <div className="mb-3">
               <h4 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-2">Instagram Posts</h4>
               <div className="space-y-2">
-                {day.instagramPosts.map(post => (
+                {safeDayInstagramPosts.map(post => (
                   <div key={post.id} className="border border-gray-200 dark:border-gray-700 rounded-sm p-2">
                     <SafeExternalLink url={post.url} className="text-blue-500 dark:text-blue-400 text-sm hover:underline">
                       View Instagram Post
@@ -284,11 +295,11 @@ const DayCard: React.FC<DayCardProps> = ({ day, isExpanded, isSelected, onClick,
           )}
 
           {/* TikTok Posts */}
-          {day.tikTokPosts && day.tikTokPosts.length > 0 && (
+          {safeDayTikTokPosts.length > 0 && (
             <div className="mb-3">
               <h4 className="text-sm font-semibold text-gray-500 dark:text-gray-400 mb-2">TikTok Posts</h4>
               <div className="space-y-2">
-                {day.tikTokPosts.map(post => (
+                {safeDayTikTokPosts.map(post => (
                   <div key={post.id} className="border border-gray-200 dark:border-gray-700 rounded-sm p-2">
                     <SafeExternalLink
                       url={post.url}

--- a/src/app/components/__tests__/Timeline.test.tsx
+++ b/src/app/components/__tests__/Timeline.test.tsx
@@ -72,5 +72,7 @@ describe('Timeline post links', () => {
     expect(hrefs).not.toContain('javascript:alert(1)');
     expect(hrefs).not.toContain('data:text/html,<script>alert(1)</script>');
     expect(hrefs).not.toContain('vbscript:msgbox(1)');
+    expect(screen.queryByText('Unsafe blog post')).not.toBeInTheDocument();
+    expect(screen.queryByText('unsafe clip')).not.toBeInTheDocument();
   });
 });

--- a/src/app/components/__tests__/Timeline.test.tsx
+++ b/src/app/components/__tests__/Timeline.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import Timeline from '@/app/components/Timeline';
+import type { Journey } from '@/app/types';
+
+jest.mock('@/app/components/AccommodationDisplay', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const journeyWithPostUrls: Journey = {
+  id: 'journey-1',
+  title: 'Test Journey',
+  startDate: new Date('2026-01-01T00:00:00.000Z'),
+  endDate: new Date('2026-01-02T00:00:00.000Z'),
+  days: [
+    {
+      id: 'day-1',
+      title: 'Day One',
+      date: new Date('2026-01-01T00:00:00.000Z'),
+      locations: [
+        {
+          id: 'location-1',
+          name: 'Paris',
+          coordinates: [48.8566, 2.3522],
+          date: new Date('2026-01-01T00:00:00.000Z'),
+          blogPosts: [
+            { id: 'blog-safe', title: 'Safe blog post', url: 'https://example.com/blog' },
+            { id: 'blog-unsafe', title: 'Unsafe blog post', url: 'javascript:alert(1)' },
+          ],
+          instagramPosts: [
+            { id: 'ig-safe-location', url: 'https://instagram.com/p/safe-location' },
+            { id: 'ig-unsafe-location', url: 'data:text/html,<script>alert(1)</script>' },
+          ],
+          tikTokPosts: [
+            { id: 'tt-safe-location', url: 'http://example.com/tiktok-location', caption: 'safe clip' },
+            { id: 'tt-unsafe-location', url: 'vbscript:msgbox(1)', caption: 'unsafe clip' },
+          ],
+        },
+      ],
+      instagramPosts: [
+        { id: 'ig-safe-day', url: 'https://instagram.com/p/safe-day' },
+        { id: 'ig-unsafe-day', url: 'javascript:alert(1)' },
+      ],
+      tikTokPosts: [
+        { id: 'tt-safe-day', url: 'https://example.com/tiktok-day' },
+        { id: 'tt-unsafe-day', url: 'data:text/html,<script>alert(1)</script>' },
+      ],
+    },
+  ],
+};
+
+describe('Timeline post links', () => {
+  it('only renders HTTP(S) post URLs', () => {
+    render(
+      <Timeline
+        journey={journeyWithPostUrls}
+        selectedDayId="day-1"
+        onDaySelect={jest.fn()}
+        onAddDay={jest.fn()}
+      />
+    );
+
+    const hrefs = screen.getAllByRole('link').map(link => link.getAttribute('href'));
+
+    expect(hrefs).toEqual([
+      'https://example.com/blog',
+      'https://instagram.com/p/safe-location',
+      'http://example.com/tiktok-location',
+      'https://instagram.com/p/safe-day',
+      'https://example.com/tiktok-day',
+    ]);
+    expect(hrefs).not.toContain('javascript:alert(1)');
+    expect(hrefs).not.toContain('data:text/html,<script>alert(1)</script>');
+    expect(hrefs).not.toContain('vbscript:msgbox(1)');
+  });
+});


### PR DESCRIPTION
## Summary

- Reuses the shared public URL validator before Timeline renders external blog, Instagram, and TikTok post links.
- Omits unsafe non-HTTP(S) post URLs from Timeline anchors so `javascript:`, `data:`, and similar schemes are not reachable through rendered `href`s.
- Adds a focused Timeline component test covering location-level and day-level post links.

## Root Cause

PR #318 added server-side public post URL filtering for map/embed payloads, but Timeline still rendered post URLs directly with `href={post.url}`. Any unsafe scheme that reached this client component could therefore become a clickable external link.

## Validation

- `bun run test:unit -- src/app/components/__tests__/Timeline.test.tsx --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"`
- `bun run lint`
- `bun run build`
