### PR TITLE
Harden accommodation website links

### DIFF
--- a/src/app/admin/components/AccommodationInput.tsx
+++ b/src/app/admin/components/AccommodationInput.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useId, useState } from 'react';
 import { parseAccommodationData, generateAccommodationTemplate } from '@/app/lib/privacyUtils';
+import { isSafePublicHttpUrl } from '@/app/lib/publicUrlValidation';
 
 interface AccommodationInputProps {
   accommodationData?: string;
@@ -50,6 +51,10 @@ export default function AccommodationInput({
     }
 
     const data = parsedData.data;
+    const safeWebsiteUrl = data.website && isSafePublicHttpUrl(data.website)
+      ? data.website
+      : null;
+
     return (
       <div className="bg-gray-50 dark:bg-gray-800 p-3 rounded-md">
         <h5 className="font-medium text-gray-900 dark:text-gray-100 mb-2">Structured View:</h5>
@@ -63,14 +68,18 @@ export default function AccommodationInput({
           {data.website && (
             <div>
               <span className="font-medium">Website:</span>{' '}
-              <a 
-                href={data.website} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                className="text-blue-500 hover:underline"
-              >
-                {data.website}
-              </a>
+              {safeWebsiteUrl ? (
+                <a 
+                  href={safeWebsiteUrl} 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  className="text-blue-500 hover:underline"
+                >
+                  {data.website}
+                </a>
+              ) : (
+                <span>{data.website}</span>
+              )}
             </div>
           )}
           {data.phone && (

--- a/src/app/admin/components/AccommodationReadOnlyDisplay.tsx
+++ b/src/app/admin/components/AccommodationReadOnlyDisplay.tsx
@@ -2,6 +2,7 @@
 
 import { Accommodation, CostTrackingData } from '@/app/types';
 import { parseAccommodationData } from '@/app/lib/privacyUtils';
+import { isSafePublicHttpUrl } from '@/app/lib/publicUrlValidation';
 import { ExpenseTravelLookup } from '@/app/lib/expenseTravelLookup';
 import { formatCurrency } from '@/app/lib/costUtils';
 import { useExpenseLinksForTravelItem } from '@/app/hooks/useExpenseLinks';
@@ -22,6 +23,9 @@ export default function AccommodationReadOnlyDisplay({
   className = ''
 }: AccommodationReadOnlyDisplayProps) {
   const parsedData = parseAccommodationData(accommodation.accommodationData || '');
+  const safeWebsiteUrl = parsedData.data?.website && isSafePublicHttpUrl(parsedData.data.website)
+    ? parsedData.data.website
+    : null;
   
   // Use our new SWR hooks for real-time data
   const { expenseLinks } = useExpenseLinksForTravelItem(tripId, accommodation.id);
@@ -58,14 +62,20 @@ export default function AccommodationReadOnlyDisplay({
         {data.website && (
           <div className="flex items-center gap-2 text-sm">
             <span>🌐</span>
-            <a 
-              href={data.website} 
-              target="_blank" 
-              rel="noopener noreferrer"
-              className="text-blue-500 hover:underline"
-            >
-              {data.website}
-            </a>
+            {safeWebsiteUrl ? (
+              <a 
+                href={safeWebsiteUrl} 
+                target="_blank" 
+                rel="noopener noreferrer"
+                className="text-blue-500 hover:underline"
+              >
+                {data.website}
+              </a>
+            ) : (
+              <span className="text-gray-800 dark:text-gray-200">
+                {data.website}
+              </span>
+            )}
           </div>
         )}
         

--- a/src/app/admin/components/__tests__/AccommodationInput.test.tsx
+++ b/src/app/admin/components/__tests__/AccommodationInput.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import AccommodationInput from '@/app/admin/components/AccommodationInput';
+
+const renderInput = (website: string) => render(
+  <AccommodationInput
+    accommodationData={`---
+name: Test Hotel
+website: ${website}
+---`}
+    isAccommodationPublic={false}
+    onAccommodationDataChange={jest.fn()}
+    onPrivacyChange={jest.fn()}
+  />
+);
+
+describe('AccommodationInput', () => {
+  it('renders safe website schemes as preview links', async () => {
+    const user = userEvent.setup();
+    renderInput('https://hotel.example');
+
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+
+    expect(screen.getByRole('link', { name: 'https://hotel.example' })).toHaveAttribute(
+      'href',
+      'https://hotel.example'
+    );
+  });
+
+  it('does not render unsafe website schemes as preview links', async () => {
+    const user = userEvent.setup();
+    renderInput('javascript:alert(1)');
+
+    await user.click(screen.getByRole('button', { name: /preview/i }));
+
+    expect(screen.getByText('javascript:alert(1)')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'javascript:alert(1)' })).not.toBeInTheDocument();
+  });
+});

--- a/src/app/admin/components/__tests__/AccommodationReadOnlyDisplay.test.tsx
+++ b/src/app/admin/components/__tests__/AccommodationReadOnlyDisplay.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AccommodationReadOnlyDisplay from '@/app/admin/components/AccommodationReadOnlyDisplay';
+import { Accommodation } from '@/app/types';
+import { useExpenseLinksForTravelItem } from '@/app/hooks/useExpenseLinks';
+import { useExpenses } from '@/app/hooks/useExpenses';
+
+jest.mock('@/app/hooks/useExpenseLinks', () => ({
+  useExpenseLinksForTravelItem: jest.fn()
+}));
+
+jest.mock('@/app/hooks/useExpenses', () => ({
+  useExpenses: jest.fn()
+}));
+
+const mockUseExpenseLinksForTravelItem = jest.mocked(useExpenseLinksForTravelItem);
+const mockUseExpenses = jest.mocked(useExpenses);
+
+const buildAccommodation = (website: string): Accommodation => ({
+  id: 'acc-1',
+  name: 'Test Hotel',
+  locationId: 'loc-1',
+  accommodationData: `---
+name: Test Hotel
+website: ${website}
+---`,
+  isAccommodationPublic: false,
+  createdAt: '2026-05-19T00:00:00.000Z'
+});
+
+describe('AccommodationReadOnlyDisplay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseExpenseLinksForTravelItem.mockReturnValue({
+      expenseLinks: [],
+      isLoading: false,
+      error: null,
+      mutate: jest.fn()
+    });
+
+    mockUseExpenses.mockReturnValue({
+      expenses: [],
+      isLoading: false,
+      error: null,
+      mutate: jest.fn()
+    });
+  });
+
+  it('renders http and https accommodation websites as external links', () => {
+    render(
+      <AccommodationReadOnlyDisplay
+        accommodation={buildAccommodation('https://hotel.example')}
+        tripId="trip-1"
+      />
+    );
+
+    expect(screen.getByRole('link', { name: 'https://hotel.example' })).toHaveAttribute(
+      'href',
+      'https://hotel.example'
+    );
+  });
+
+  it('does not render unsafe accommodation website schemes as clickable links', () => {
+    render(
+      <AccommodationReadOnlyDisplay
+        accommodation={buildAccommodation('javascript:alert(1)')}
+        tripId="trip-1"
+      />
+    );
+
+    expect(screen.getByText('javascript:alert(1)')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'javascript:alert(1)' })).not.toBeInTheDocument();
+  });
+});

--- a/src/app/components/AccommodationDisplay.tsx
+++ b/src/app/components/AccommodationDisplay.tsx
@@ -5,6 +5,7 @@ import { parseAccommodationData, PrivacyOptions } from '@/app/lib/privacyUtils';
 import { ExpenseTravelLookup } from '@/app/lib/expenseTravelLookup';
 import { CostTrackingData } from '@/app/types';
 import { formatCurrency } from '@/app/lib/costUtils';
+import { isSafePublicHttpUrl } from '@/app/lib/publicUrlValidation';
 
 interface AccommodationDisplayProps {
   accommodationData?: string;
@@ -64,6 +65,9 @@ export default function AccommodationDisplay({
     }
 
     const data = parsedAccommodationData.data;
+    const safeWebsiteUrl = data.website && isSafePublicHttpUrl(data.website)
+      ? data.website
+      : null;
     
     return (
       <div className={`space-y-2 ${className}`}>
@@ -98,14 +102,20 @@ export default function AccommodationDisplay({
           {data.website && (
             <div className="flex items-center gap-2 text-sm">
               <span>🌐</span>
-              <a 
-                href={data.website} 
-                target="_blank" 
-                rel="noopener noreferrer"
-                className="text-blue-500 hover:underline"
-              >
-                {data.website}
-              </a>
+              {safeWebsiteUrl ? (
+                <a 
+                  href={safeWebsiteUrl} 
+                  target="_blank" 
+                  rel="noopener noreferrer"
+                  className="text-blue-500 hover:underline"
+                >
+                  {data.website}
+                </a>
+              ) : (
+                <span className="text-gray-800 dark:text-gray-200">
+                  {data.website}
+                </span>
+              )}
             </div>
           )}
           


### PR DESCRIPTION
## Summary
- render accommodation website URLs as links only when they use safe HTTP(S) schemes
- keep unsafe website values visible as text in admin read-only, edit preview, and shared accommodation displays
- add focused component coverage for safe and unsafe accommodation website values

## Validation
- bun run test:unit -- src/app/admin/components/__tests__/AccommodationReadOnlyDisplay.test.tsx src/app/admin/components/__tests__/AccommodationInput.test.tsx --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint