### PR TITLE
Defend accommodation export names

### DIFF
--- a/src/app/admin/edit/[tripId]/page.tsx
+++ b/src/app/admin/edit/[tripId]/page.tsx
@@ -123,14 +123,20 @@ export default function TripEditorPage() {
   }, []);
 
   const accommodationsByLocation = useMemo(() => {
-    const map = new Map<string, string[]>();
+    const map = new Map<string, unknown[]>();
     (travelData.accommodations || []).forEach(accommodation => {
-      if (!accommodation.locationId) {
+      if (!accommodation || typeof accommodation !== 'object') {
         return;
       }
-      const existing = map.get(accommodation.locationId) || [];
-      existing.push(accommodation.name);
-      map.set(accommodation.locationId, existing);
+
+      const { locationId, name } = accommodation as { locationId?: unknown; name?: unknown };
+      if (typeof locationId !== 'string' || !locationId) {
+        return;
+      }
+
+      const existing = map.get(locationId) || [];
+      existing.push(name);
+      map.set(locationId, existing);
     });
     return map;
   }, [travelData.accommodations]);
@@ -203,8 +209,8 @@ export default function TripEditorPage() {
     return totals;
   }, [costData, travelLookup]);
 
-  const collapseText = useCallback((text?: string) => {
-    if (!text) {
+  const collapseText = useCallback((text?: unknown) => {
+    if (typeof text !== 'string') {
       return '';
     }
     return text.replace(/\s+/g, ' ').trim();

--- a/src/app/lib/__tests__/combineAccommodationDescriptions.test.ts
+++ b/src/app/lib/__tests__/combineAccommodationDescriptions.test.ts
@@ -16,4 +16,21 @@ describe('combineAccommodationDescriptions', () => {
   it('trims and ignores empty values', () => {
     expect(combineAccommodationDescriptions(['  A  ', ''], '   ')).toEqual(['A']);
   });
+
+  it('ignores malformed accommodation names without dropping valid values', () => {
+    expect(
+      combineAccommodationDescriptions([
+        'Hotel',
+        null,
+        undefined,
+        { name: 'bad shape' },
+        42,
+        '  Guesthouse  '
+      ], 'Legacy place')
+    ).toEqual(['Hotel', 'Guesthouse', 'Legacy place']);
+  });
+
+  it('ignores malformed legacy accommodation data', () => {
+    expect(combineAccommodationDescriptions(['Hotel'], { text: 'Legacy place' })).toEqual(['Hotel']);
+  });
 });

--- a/src/app/lib/combineAccommodationDescriptions.ts
+++ b/src/app/lib/combineAccommodationDescriptions.ts
@@ -7,12 +7,12 @@
  * - Deduplicates case-insensitively
  */
 export function combineAccommodationDescriptions(
-  accommodationNames: string[],
-  legacyAccommodation?: string | null
+  accommodationNames: unknown[],
+  legacyAccommodation?: unknown
 ): string[] {
-  const combined = [...accommodationNames];
+  const combined = accommodationNames.filter((name): name is string => typeof name === 'string');
 
-  const legacy = (legacyAccommodation || '').trim();
+  const legacy = typeof legacyAccommodation === 'string' ? legacyAccommodation.trim() : '';
   if (legacy) {
     combined.push(legacy);
   }


### PR DESCRIPTION
## Summary
- ignore malformed accommodation records and invalid location IDs while grouping export accommodations
- make accommodation description combination tolerate non-string names and legacy values
- add focused unit coverage for malformed accommodation names and legacy data

## Validation
- bun run test:unit -- src/app/lib/__tests__/combineAccommodationDescriptions.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint