### PR TITLE
Persist cleared reserved budgets

### DIFF
--- a/src/app/__tests__/lib/costDataDelta.test.ts
+++ b/src/app/__tests__/lib/costDataDelta.test.ts
@@ -123,12 +123,34 @@ describe('costDataDelta', () => {
     expect(merged.countryBudgets).toHaveLength(1);
   });
 
+  it('serializes a cleared reserved budget as null so JSON PATCH preserves the clear intent', () => {
+    const previous = buildCostData();
+    const current: CostTrackingData = {
+      ...previous,
+      reservedBudget: undefined
+    };
+
+    const delta = createCostDataDelta(previous, current);
+
+    expect(delta).toEqual({ reservedBudget: null });
+    expect(JSON.stringify({ deltaUpdate: delta })).toContain('"reservedBudget":null');
+  });
+
+  it('applies null reserved budget deltas as a cleared reserved budget', () => {
+    const previous = buildCostData();
+
+    const merged = applyCostDataDelta(previous, { reservedBudget: null });
+
+    expect(merged.reservedBudget).toBeUndefined();
+  });
+
   it('validates delta payload shape', () => {
     expect(isCostDataDelta({ expenses: { added: [] } })).toBe(true);
     expect(isCostDataDelta({ countryBudgets: [] })).toBe(false);
     expect(isCostDataDelta({ customCategories: 'not-array' })).toBe(false);
     expect(isCostDataDelta({ overallBudget: 'not-a-number' })).toBe(false);
     expect(isCostDataDelta({ reservedBudget: Number.NaN })).toBe(false);
+    expect(isCostDataDelta({ reservedBudget: null })).toBe(true);
     expect(isCostDataDelta({ customCategories: ['Food', 123] })).toBe(false);
   });
 

--- a/src/app/__tests__/lib/unifiedDataService.costData.test.ts
+++ b/src/app/__tests__/lib/unifiedDataService.costData.test.ts
@@ -82,4 +82,25 @@ describe('unifiedDataService.updateCostData reserved budget persistence', () => 
 
     expect(reloaded?.costData?.reservedBudget).toBe(250);
   });
+
+  it('does not persist NaN for malformed reserved budget values', async () => {
+    const { updateCostData, loadUnifiedTripData } = await import('../../lib/unifiedDataService');
+
+    await seedCostTrip('reservedBudgetMalformed', 250);
+
+    await updateCostData('reservedBudgetMalformed', {
+      tripTitle: 'Reserved Budget Malformed',
+      tripStartDate: '2025-01-01',
+      tripEndDate: '2025-01-02',
+      overallBudget: 1000,
+      reservedBudget: 'not-a-number',
+      currency: 'EUR',
+      countryBudgets: [],
+      expenses: []
+    });
+
+    const reloaded = await loadUnifiedTripData('reservedBudgetMalformed');
+
+    expect(reloaded?.costData?.reservedBudget).toBe(0);
+  });
 });

--- a/src/app/__tests__/lib/unifiedDataService.costData.test.ts
+++ b/src/app/__tests__/lib/unifiedDataService.costData.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('unifiedDataService.updateCostData reserved budget persistence', () => {
+  let testDataDir: string;
+  const createdAt = '2025-01-01T00:00:00.000Z';
+
+  const seedCostTrip = async (tripId: string, reservedBudget: number) => {
+    const { saveUnifiedTripData } = await import('../../lib/unifiedDataService');
+    const { CURRENT_SCHEMA_VERSION } = await import('../../lib/dataMigration');
+
+    await saveUnifiedTripData({
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+      id: tripId,
+      title: 'Reserved Budget Trip',
+      description: '',
+      startDate: '2025-01-01',
+      endDate: '2025-01-02',
+      createdAt,
+      updatedAt: createdAt,
+      costData: {
+        overallBudget: 1000,
+        reservedBudget,
+        currency: 'EUR',
+        countryBudgets: [],
+        expenses: []
+      }
+    });
+  };
+
+  beforeEach(() => {
+    testDataDir = mkdtempSync(join(tmpdir(), 'travel-tracker-cost-data-'));
+    process.env.TEST_DATA_DIR = testDataDir;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    delete process.env.TEST_DATA_DIR;
+    jest.resetModules();
+    rmSync(testDataDir, { recursive: true, force: true });
+  });
+
+  it('persists an explicit reserved budget clear instead of restoring the previous value', async () => {
+    const { updateCostData, loadUnifiedTripData } = await import('../../lib/unifiedDataService');
+
+    await seedCostTrip('reservedBudgetClear', 250);
+
+    await updateCostData('reservedBudgetClear', {
+      tripTitle: 'Reserved Budget Clear',
+      tripStartDate: '2025-01-01',
+      tripEndDate: '2025-01-02',
+      overallBudget: 1000,
+      reservedBudget: null,
+      currency: 'EUR',
+      countryBudgets: [],
+      expenses: []
+    });
+
+    const reloaded = await loadUnifiedTripData('reservedBudgetClear');
+
+    expect(reloaded?.costData?.reservedBudget).toBeUndefined();
+  });
+
+  it('preserves reserved budget when an update omits the field', async () => {
+    const { updateCostData, loadUnifiedTripData } = await import('../../lib/unifiedDataService');
+
+    await seedCostTrip('reservedBudgetOmitted', 250);
+
+    await updateCostData('reservedBudgetOmitted', {
+      tripTitle: 'Reserved Budget Omitted',
+      tripStartDate: '2025-01-01',
+      tripEndDate: '2025-01-02',
+      overallBudget: 1000,
+      currency: 'EUR',
+      countryBudgets: [],
+      expenses: []
+    });
+
+    const reloaded = await loadUnifiedTripData('reservedBudgetOmitted');
+
+    expect(reloaded?.costData?.reservedBudget).toBe(250);
+  });
+});

--- a/src/app/admin/cost-tracking/[costId]/page.tsx
+++ b/src/app/admin/cost-tracking/[costId]/page.tsx
@@ -19,11 +19,17 @@ import { getCachedCostTracker, setCachedCostTracker } from '@/app/lib/costTracke
 function migrateCostData(costData: CostTrackingData): CostTrackingData {
   return {
     ...costData,
-    reservedBudget: costData.reservedBudget ?? 0,
     expenses: costData.expenses.map((expense) => ({
       ...expense,
       expenseType: expense.expenseType || 'actual'
     }))
+  };
+}
+
+function serializeCostDataForSave(costData: CostTrackingData): Omit<CostTrackingData, 'reservedBudget'> & { reservedBudget: number | null } {
+  return {
+    ...costData,
+    reservedBudget: costData.reservedBudget ?? null
   };
 }
 
@@ -207,7 +213,7 @@ export default function CostTrackingPage() {
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify(costData),
+          body: JSON.stringify(serializeCostDataForSave(costData)),
         });
       } catch (error) {
         console.warn('Auto-save (full) network failure, queuing offline delta:', error);
@@ -392,8 +398,8 @@ export default function CostTrackingPage() {
       const url = isNewCostTracker ? `${baseUrl}/api/cost-tracking` : `${baseUrl}/api/cost-tracking?id=${costData.id}`;
       
       const dataToSave = isNewCostTracker 
-        ? { ...costData, id: undefined }
-        : costData;
+        ? { ...serializeCostDataForSave(costData), id: undefined }
+        : serializeCostDataForSave(costData);
       
       const response = await fetch(url, {
         method,

--- a/src/app/api/cost-tracking/route.ts
+++ b/src/app/api/cost-tracking/route.ts
@@ -33,7 +33,7 @@ export async function POST(request: NextRequest) {
     const legacyData = {
       id,
       ...costData,
-      reservedBudget: costData.reservedBudget || 0,
+      reservedBudget: costData.reservedBudget ?? undefined,
       createdAt: unifiedData.createdAt
     };
     
@@ -100,7 +100,7 @@ export async function GET(request: NextRequest) {
       tripStartDate: unifiedData.startDate,
       tripEndDate: unifiedData.endDate,
       overallBudget: unifiedData.costData.overallBudget,
-      reservedBudget: unifiedData.costData.reservedBudget || 0,
+      reservedBudget: unifiedData.costData.reservedBudget,
       currency: unifiedData.costData.currency,
       customCategories: unifiedData.costData.customCategories,
       countryBudgets: unifiedData.costData.countryBudgets,
@@ -160,7 +160,7 @@ export async function PUT(request: NextRequest) {
     const legacyData = {
       id: cleanId,
       ...updatedData,
-      reservedBudget: updatedData.reservedBudget || 0,
+      reservedBudget: updatedData.reservedBudget ?? undefined,
       updatedAt: unifiedData.updatedAt
     };
     
@@ -237,7 +237,7 @@ export async function PATCH(request: NextRequest) {
       tripStartDate: parseDateAsLocalDay(unifiedData.startDate) ?? new Date(),
       tripEndDate: parseDateAsLocalDay(unifiedData.endDate) ?? new Date(),
       overallBudget: unifiedData.costData.overallBudget,
-      reservedBudget: unifiedData.costData.reservedBudget || 0,
+      reservedBudget: unifiedData.costData.reservedBudget,
       currency: unifiedData.costData.currency,
       customCategories: unifiedData.costData.customCategories,
       countryBudgets: unifiedData.costData.countryBudgets,

--- a/src/app/lib/costDataDelta.ts
+++ b/src/app/lib/costDataDelta.ts
@@ -15,7 +15,7 @@ export type CostDataDelta = {
   tripStartDate?: Date | string;
   tripEndDate?: Date | string;
   overallBudget?: number;
-  reservedBudget?: number;
+  reservedBudget?: number | null;
   currency?: string;
   customCategories?: string[];
   countryBudgets?: CollectionDelta<BudgetItem>;
@@ -72,7 +72,7 @@ export const createCostDataDelta = (
   }
 
   if (serialize(previous.reservedBudget) !== serialize(current.reservedBudget)) {
-    delta.reservedBudget = current.reservedBudget;
+    delta.reservedBudget = current.reservedBudget ?? null;
   }
 
   if (serialize(previous.currency) !== serialize(current.currency)) {
@@ -131,7 +131,7 @@ export const applyCostDataDelta = (
   }
 
   if (Object.prototype.hasOwnProperty.call(delta, 'reservedBudget')) {
-    next.reservedBudget = delta.reservedBudget;
+    next.reservedBudget = delta.reservedBudget ?? undefined;
   }
 
   if (Object.prototype.hasOwnProperty.call(delta, 'currency') && delta.currency !== undefined) {
@@ -160,7 +160,7 @@ export const isCostDataDelta = (value: unknown): value is CostDataDelta => {
   if (value.tripStartDate !== undefined && !isDateLike(value.tripStartDate)) return false;
   if (value.tripEndDate !== undefined && !isDateLike(value.tripEndDate)) return false;
   if (value.overallBudget !== undefined && !isFiniteNumber(value.overallBudget)) return false;
-  if (value.reservedBudget !== undefined && !isFiniteNumber(value.reservedBudget)) return false;
+  if (value.reservedBudget !== undefined && value.reservedBudget !== null && !isFiniteNumber(value.reservedBudget)) return false;
   if (value.currency !== undefined && typeof value.currency !== 'string') return false;
 
   if (value.countryBudgets !== undefined && !isCollectionDeltaShape(value.countryBudgets)) {

--- a/src/app/lib/unifiedDataService.ts
+++ b/src/app/lib/unifiedDataService.ts
@@ -792,10 +792,11 @@ export async function updateCostData(tripId: string, costUpdates: Record<string,
   const overallBudget = Math.max(0, incomingOverall);
   const hasReservedBudgetUpdate = Object.prototype.hasOwnProperty.call(costUpdates, 'reservedBudget');
   const incomingReserved = costUpdates.reservedBudget;
+  const incomingReservedNumber = Number(incomingReserved);
   const reservedBudget = hasReservedBudgetUpdate
     ? incomingReserved === null || incomingReserved === undefined
       ? undefined
-      : Math.min(Math.max(0, incomingReserved as number), overallBudget)
+      : Math.min(Math.max(0, Number.isFinite(incomingReservedNumber) ? incomingReservedNumber : 0), overallBudget)
     : existing?.costData?.reservedBudget;
 
   const defaultData: UnifiedTripData = {

--- a/src/app/lib/unifiedDataService.ts
+++ b/src/app/lib/unifiedDataService.ts
@@ -790,8 +790,13 @@ export async function updateCostData(tripId: string, costUpdates: Record<string,
 
   const incomingOverall = (costUpdates.overallBudget as number) ?? existing?.costData?.overallBudget ?? 0;
   const overallBudget = Math.max(0, incomingOverall);
-  const incomingReserved = (costUpdates.reservedBudget as number) ?? existing?.costData?.reservedBudget ?? 0;
-  const reservedBudget = Math.min(Math.max(0, incomingReserved), overallBudget);
+  const hasReservedBudgetUpdate = Object.prototype.hasOwnProperty.call(costUpdates, 'reservedBudget');
+  const incomingReserved = costUpdates.reservedBudget;
+  const reservedBudget = hasReservedBudgetUpdate
+    ? incomingReserved === null || incomingReserved === undefined
+      ? undefined
+      : Math.min(Math.max(0, incomingReserved as number), overallBudget)
+    : existing?.costData?.reservedBudget;
 
   const defaultData: UnifiedTripData = {
     schemaVersion: CURRENT_SCHEMA_VERSION,


### PR DESCRIPTION
## Summary
- serialize cleared reserved budgets as explicit null across save and delta paths
- preserve existing reserved budgets when update payloads omit the field
- stop load/save migration from forcing missing reserved budget values back to 0
- add focused delta and unified data service tests for clear-vs-omit behavior

## Validation
- bun run test:unit -- src/app/__tests__/lib/costDataDelta.test.ts src/app/__tests__/lib/unifiedDataService.costData.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint
- bun run build