### PR TITLE
Keep zero-distance sub-routes in summaries

### DIFF
--- a/src/app/admin/edit/[tripId]/components/DistanceSummary.tsx
+++ b/src/app/admin/edit/[tripId]/components/DistanceSummary.tsx
@@ -36,10 +36,10 @@ function calculateDistanceFromPoints(points: [number, number][]): number {
  * Calculates the distance for a single route segment
  * Prefers distanceOverride if provided, then routePoints, then endpoint calculation
  * @param segment - TravelRouteSegment containing route data
- * @returns Distance in kilometers, doubled if doubleDistance flag is set
+ * @returns Distance in kilometers, doubled if doubleDistance flag is set, or null when no valid source exists
  */
-function getSegmentDistance(segment: TravelRoute): number {
-  let distance = 0;
+function getSegmentDistance(segment: TravelRoute): number | null {
+  let distance: number | null = null;
   const overrideDistance = segment.distanceOverride;
 
   if (typeof overrideDistance === 'number' && Number.isFinite(overrideDistance)) {
@@ -48,6 +48,10 @@ function getSegmentDistance(segment: TravelRoute): number {
     distance = calculateDistanceFromPoints(segment.routePoints);
   } else if (segment.fromCoords && segment.toCoords) {
     distance = calculateDistance(segment.fromCoords, segment.toCoords);
+  }
+
+  if (distance === null || !Number.isFinite(distance)) {
+    return null;
   }
 
   // Double the distance if the segment has doubleDistance flag set
@@ -120,7 +124,7 @@ export default function DistanceSummary({ routes }: DistanceSummaryProps) {
       if (route.subRoutes && route.subRoutes.length > 0) {
         route.subRoutes.forEach(subRoute => {
           const distance = getSegmentDistance(subRoute);
-          if (distance === 0) return;
+          if (distance === null) return;
 
           const type = normalizeTransportationType(subRoute.transportType);
           const existing = byType.get(type) || { distance: 0, count: 0 };
@@ -152,7 +156,7 @@ export default function DistanceSummary({ routes }: DistanceSummaryProps) {
         });
       } else {
         // For simple routes, use the route's transport type
-        const routeDistance = getSegmentDistance(route);
+        const routeDistance = getSegmentDistance(route) ?? 0;
         const type = normalizeTransportationType(route.transportType);
         const existing = byType.get(type) || { distance: 0, count: 0 };
         byType.set(type, {

--- a/src/app/admin/edit/[tripId]/components/__tests__/DistanceSummary.test.tsx
+++ b/src/app/admin/edit/[tripId]/components/__tests__/DistanceSummary.test.tsx
@@ -248,6 +248,51 @@ describe('DistanceSummary', () => {
       expect(screen.getByText(/Total distance across 1 route/)).toBeInTheDocument();
     });
 
+    it('includes valid zero-distance subRoutes in type summaries', () => {
+      const routeWithZeroDistanceSubRoute: TravelRoute = {
+        ...routeWithSubRoutes,
+        subRoutes: [
+          {
+            ...routeWithSubRoutes.subRoutes![0],
+            transportType: 'train',
+            distanceOverride: 0,
+            routePoints: [
+              [40.7128, -74.0060],
+              [45.0, -60.0],
+              [51.5074, -0.1278]
+            ]
+          }
+        ]
+      };
+
+      render(<DistanceSummary routes={[routeWithZeroDistanceSubRoute]} />);
+
+      expect(screen.getByText(/By transportation type \(all routes\):/)).toBeInTheDocument();
+      expect(screen.getByText('Train')).toBeInTheDocument();
+      expect(screen.getByText('(1 route)')).toBeInTheDocument();
+      expect(screen.getAllByText('0.0 km').length).toBeGreaterThan(1);
+    });
+
+    it('does not add subRoutes with no valid distance source to type summaries', () => {
+      const routeWithMissingDistanceSubRoute: TravelRoute = {
+        ...routeWithSubRoutes,
+        subRoutes: [
+          {
+            ...routeWithSubRoutes.subRoutes![0],
+            transportType: 'train',
+            fromCoords: undefined,
+            toCoords: undefined,
+            routePoints: undefined
+          } as Partial<TravelRoute> as TravelRoute
+        ]
+      };
+
+      render(<DistanceSummary routes={[routeWithMissingDistanceSubRoute]} />);
+
+      expect(screen.queryByText(/By transportation type \(all routes\):/)).not.toBeInTheDocument();
+      expect(screen.queryByText('Train')).not.toBeInTheDocument();
+    });
+
     it('normalizes malformed sub-route transport types before rendering breakdowns', () => {
       const malformedSubRoute = {
         ...routeWithSubRoutes,


### PR DESCRIPTION
## Summary
- distinguish missing sub-route distance from valid zero-distance values
- keep zero-distance sub-routes in transportation type counts and summaries
- preserve simple-route fallback behavior for routes without usable distance data
- add focused DistanceSummary coverage for zero-distance and missing-distance sub-routes

## Validation
- bun run test:unit -- --runTestsByPath 'src/app/admin/edit/[tripId]/components/__tests__/DistanceSummary.test.tsx' --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint