### PR TITLE
Keep refund category managed

### DIFF
--- a/src/app/__tests__/utils.test.ts
+++ b/src/app/__tests__/utils.test.ts
@@ -24,7 +24,9 @@ import {
   calculateCostSummary,
   generateId,
   getExpensesByCountry,
-  EXPENSE_CATEGORIES
+  EXPENSE_CATEGORIES,
+  REFUNDS_CATEGORY_NAME,
+  ensureManagedExpenseCategories
 } from '@/app/lib/costUtils';
 
 import { parseAccommodationData } from '@/app/lib/privacyUtils';
@@ -397,7 +399,16 @@ Some	Invalid	Data`;
       expect(EXPENSE_CATEGORIES).toContain('Accommodation');
       expect(EXPENSE_CATEGORIES).toContain('Transportation');
       expect(EXPENSE_CATEGORIES).toContain('Activities & Tours');
+      expect(EXPENSE_CATEGORIES).toContain(REFUNDS_CATEGORY_NAME);
       expect(EXPENSE_CATEGORIES.length).toBeGreaterThan(5);
+    });
+
+    it('should restore managed refund categories to legacy custom category lists', () => {
+      expect(ensureManagedExpenseCategories(['Food & Dining'])).toEqual([
+        'Food & Dining',
+        'Local currency held in cash',
+        REFUNDS_CATEGORY_NAME
+      ]);
     });
   });
 

--- a/src/app/admin/components/CostTracking/CategoryManager.tsx
+++ b/src/app/admin/components/CostTracking/CategoryManager.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { CostTrackingData } from '@/app/types';
-import { CASH_CATEGORY_NAME } from '@/app/lib/costUtils';
+import { isManagedExpenseCategory } from '@/app/lib/costUtils';
 
 interface CategoryManagerProps {
   costData: CostTrackingData;
@@ -38,16 +38,16 @@ export default function CategoryManager({
       alert('This category already exists.');
       return;
     }
-    if (newCategory.trim() === CASH_CATEGORY_NAME) {
-      alert(`"${CASH_CATEGORY_NAME}" is automatically managed and cannot be added manually.`);
+    if (isManagedExpenseCategory(newCategory.trim())) {
+      alert(`"${newCategory.trim()}" is automatically managed and cannot be added manually.`);
       return;
     }
 
     if (editingCategoryIndex !== null) {
       // Edit existing category
       const updatedCategories = [...currentCategories];
-      if (updatedCategories[editingCategoryIndex] === CASH_CATEGORY_NAME) {
-        alert(`"${CASH_CATEGORY_NAME}" cannot be renamed.`);
+      if (isManagedExpenseCategory(updatedCategories[editingCategoryIndex])) {
+        alert(`"${updatedCategories[editingCategoryIndex]}" cannot be renamed.`);
         return;
       }
       updatedCategories[editingCategoryIndex] = newCategory.trim();
@@ -73,8 +73,8 @@ export default function CategoryManager({
   const deleteCategory = (index: number) => {
     const currentCategories = getCategories();
     const categoryToDelete = currentCategories[index];
-    if (categoryToDelete === CASH_CATEGORY_NAME) {
-      alert(`"${CASH_CATEGORY_NAME}" is required for cash handling and cannot be deleted.`);
+    if (isManagedExpenseCategory(categoryToDelete)) {
+      alert(`"${categoryToDelete}" is required for cash/refund handling and cannot be deleted.`);
       return;
     }
     
@@ -139,7 +139,7 @@ export default function CategoryManager({
                 <div key={category} className="flex justify-between items-center bg-white dark:bg-gray-800 p-3 rounded-sm border dark:border-gray-700">
                   <span className="font-medium text-sm">
                     {category}
-                    {category === CASH_CATEGORY_NAME && (
+                    {isManagedExpenseCategory(category) && (
                       <span className="ml-2 text-xs text-yellow-700 dark:text-yellow-300">(required)</span>
                     )}
                   </span>
@@ -147,14 +147,14 @@ export default function CategoryManager({
                     <button
                       onClick={() => editCategory(index)}
                       className="text-blue-500 hover:text-blue-700 text-xs disabled:opacity-50 disabled:cursor-not-allowed"
-                      disabled={category === CASH_CATEGORY_NAME}
+                      disabled={isManagedExpenseCategory(category)}
                     >
                       Edit
                     </button>
                     <button
                       onClick={() => deleteCategory(index)}
                       className="text-red-500 hover:text-red-700 text-xs disabled:opacity-50 disabled:cursor-not-allowed"
-                      disabled={category === CASH_CATEGORY_NAME}
+                      disabled={isManagedExpenseCategory(category)}
                     >
                       Delete
                     </button>

--- a/src/app/admin/components/CostTracking/CostTrackerEditor.tsx
+++ b/src/app/admin/components/CostTracking/CostTrackerEditor.tsx
@@ -68,6 +68,10 @@ const secondaryActionClassName = [
   'dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800',
 ].join(' ');
 
+const categoryListsEqual = (left: readonly string[], right: readonly string[]): boolean => {
+  return left.length === right.length && left.every((category, index) => category === right[index]);
+};
+
 const primaryActionClassName = [
   'inline-flex min-h-10 items-center justify-center rounded-md bg-blue-600 px-4 py-2',
   'text-sm font-semibold text-white transition hover:bg-blue-700',
@@ -201,6 +205,7 @@ export default function CostTrackerEditor({
   
   const [newCategory, setNewCategory] = useState('');
   const [editingCategoryIndex, setEditingCategoryIndex] = useState<number | null>(null);
+  const [pendingSaveAfterCategoryRepair, setPendingSaveAfterCategoryRepair] = useState(false);
   
   // YNAB Import state
   const [showYnabImport, setShowYnabImport] = useState(false);
@@ -217,19 +222,59 @@ export default function CostTrackerEditor({
     return ensureManagedExpenseCategories(costData.customCategories ?? EXPENSE_CATEGORIES);
   };
   
-  const ensureCategoriesInitialized = () => {
+  const ensureCategoriesInitialized = (): void => {
     const categories = ensureManagedExpenseCategories(costData.customCategories ?? EXPENSE_CATEGORIES);
-    if (!costData.customCategories) {
-      setCostData(prev => ({
-        ...prev,
-        customCategories: categories
-      }));
-    } else if (categories.length !== costData.customCategories.length) {
+    if (!costData.customCategories || !categoryListsEqual(costData.customCategories, categories)) {
       setCostData(prev => ({
         ...prev,
         customCategories: ensureManagedExpenseCategories(prev.customCategories ?? EXPENSE_CATEGORIES)
       }));
+      setHasUnsavedChanges(true);
     }
+  };
+
+  useEffect(() => {
+    ensureCategoriesInitialized();
+  });
+
+  useEffect(() => {
+    if (!pendingSaveAfterCategoryRepair) {
+      return;
+    }
+
+    const categories = ensureManagedExpenseCategories(costData.customCategories ?? EXPENSE_CATEGORIES);
+    if (!costData.customCategories || !categoryListsEqual(costData.customCategories, categories)) {
+      return;
+    }
+
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) {
+        return;
+      }
+
+      setPendingSaveAfterCategoryRepair(false);
+      onSave();
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [costData.customCategories, onSave, pendingSaveAfterCategoryRepair]);
+
+  const handleSave = (): void => {
+    const categories = ensureManagedExpenseCategories(costData.customCategories ?? EXPENSE_CATEGORIES);
+    if (!costData.customCategories || !categoryListsEqual(costData.customCategories, categories)) {
+      setPendingSaveAfterCategoryRepair(true);
+      setCostData(prev => ({
+        ...prev,
+        customCategories: ensureManagedExpenseCategories(prev.customCategories ?? EXPENSE_CATEGORIES)
+      }));
+      setHasUnsavedChanges(true);
+      return;
+    }
+
+    onSave();
   };
 
   const getExistingCountries = (): string[] => {
@@ -723,7 +768,7 @@ export default function CostTrackerEditor({
             )}
             <button
               type="button"
-              onClick={onSave}
+              onClick={handleSave}
               disabled={!canSave}
               className={primaryActionClassName}
             >

--- a/src/app/admin/components/CostTracking/CostTrackerEditor.tsx
+++ b/src/app/admin/components/CostTracking/CostTrackerEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import {
   Accommodation,
   CostTrackingData,
@@ -217,13 +217,16 @@ export default function CostTrackerEditor({
   const [travelLookup, setTravelLookup] = useState<ExpenseTravelLookup | null>(null);
   const [tripLocations, setTripLocations] = useState<Location[]>([]);
   const [tripAccommodations, setTripAccommodations] = useState<Accommodation[]>([]);
+  const categories = useMemo(
+    () => ensureManagedExpenseCategories(costData.customCategories ?? EXPENSE_CATEGORIES),
+    [costData.customCategories]
+  );
   
-  const getCategories = (): string[] => {
-    return ensureManagedExpenseCategories(costData.customCategories ?? EXPENSE_CATEGORIES);
-  };
+  const getCategories = useCallback((): string[] => {
+    return categories;
+  }, [categories]);
   
   const ensureCategoriesInitialized = (): void => {
-    const categories = ensureManagedExpenseCategories(costData.customCategories ?? EXPENSE_CATEGORIES);
     if (!costData.customCategories || !categoryListsEqual(costData.customCategories, categories)) {
       setCostData(prev => ({
         ...prev,
@@ -242,7 +245,6 @@ export default function CostTrackerEditor({
       return;
     }
 
-    const categories = ensureManagedExpenseCategories(costData.customCategories ?? EXPENSE_CATEGORIES);
     if (!costData.customCategories || !categoryListsEqual(costData.customCategories, categories)) {
       return;
     }
@@ -260,10 +262,9 @@ export default function CostTrackerEditor({
     return () => {
       cancelled = true;
     };
-  }, [costData.customCategories, onSave, pendingSaveAfterCategoryRepair]);
+  }, [categories, costData.customCategories, onSave, pendingSaveAfterCategoryRepair]);
 
   const handleSave = (): void => {
-    const categories = ensureManagedExpenseCategories(costData.customCategories ?? EXPENSE_CATEGORIES);
     if (!costData.customCategories || !categoryListsEqual(costData.customCategories, categories)) {
       setPendingSaveAfterCategoryRepair(true);
       setCostData(prev => ({

--- a/src/app/admin/components/CostTracking/CostTrackerEditor.tsx
+++ b/src/app/admin/components/CostTracking/CostTrackerEditor.tsx
@@ -13,7 +13,7 @@ import {
   YnabCategoryMapping,
   YnabConfig
 } from '@/app/types';
-import { calculateCostSummary, generateId, EXPENSE_CATEGORIES, CASH_CATEGORY_NAME } from '@/app/lib/costUtils';
+import { calculateCostSummary, generateId, EXPENSE_CATEGORIES, ensureManagedExpenseCategories } from '@/app/lib/costUtils';
 import { calculateExpenseTotalsByLocation, ExpenseTravelLookup, TravelLinkInfo } from '@/app/lib/expenseTravelLookup';
 import { filterExpensesByExcludedCountries } from '@/app/lib/countryInclusions';
 import BudgetSetup from '@/app/admin/components/CostTracking/BudgetSetup';
@@ -214,23 +214,20 @@ export default function CostTrackerEditor({
   const [tripAccommodations, setTripAccommodations] = useState<Accommodation[]>([]);
   
   const getCategories = (): string[] => {
-    const baseCategories = costData.customCategories ? [...costData.customCategories] : [...EXPENSE_CATEGORIES];
-    if (!baseCategories.includes(CASH_CATEGORY_NAME)) {
-      baseCategories.push(CASH_CATEGORY_NAME);
-    }
-    return baseCategories;
+    return ensureManagedExpenseCategories(costData.customCategories ?? EXPENSE_CATEGORIES);
   };
   
   const ensureCategoriesInitialized = () => {
+    const categories = ensureManagedExpenseCategories(costData.customCategories ?? EXPENSE_CATEGORIES);
     if (!costData.customCategories) {
       setCostData(prev => ({
         ...prev,
-        customCategories: Array.from(new Set([...EXPENSE_CATEGORIES, CASH_CATEGORY_NAME]))
+        customCategories: categories
       }));
-    } else if (!costData.customCategories.includes(CASH_CATEGORY_NAME)) {
+    } else if (categories.length !== costData.customCategories.length) {
       setCostData(prev => ({
         ...prev,
-        customCategories: [...prev.customCategories!, CASH_CATEGORY_NAME]
+        customCategories: ensureManagedExpenseCategories(prev.customCategories ?? EXPENSE_CATEGORIES)
       }));
     }
   };

--- a/src/app/admin/components/__tests__/CostTrackerEditor.test.tsx
+++ b/src/app/admin/components/__tests__/CostTrackerEditor.test.tsx
@@ -227,4 +227,57 @@ describe('CostTrackerEditor', () => {
     expect(screen.getByTestId('category-manager')).toHaveTextContent('Local currency held in cash');
     expect(screen.getByTestId('category-manager')).toHaveTextContent('Refunds');
   });
+
+  it('persists repaired managed categories when legacy category counts already match', async () => {
+    const initialCostData: CostTrackingData = {
+      id: 'cost-1',
+      tripId: 'trip-1',
+      tripTitle: 'Test Trip',
+      tripStartDate: new Date('2026-03-01T00:00:00.000Z'),
+      tripEndDate: new Date('2026-03-10T00:00:00.000Z'),
+      overallBudget: 1000,
+      currency: 'EUR',
+      countryBudgets: [],
+      expenses: [],
+      customCategories: ['Food', 'Food', 'Local currency held in cash'],
+      createdAt: '2026-03-01T00:00:00.000Z'
+    };
+
+    const existingTrip = {
+      id: 'trip-1',
+      title: 'Test Trip',
+      startDate: '2026-03-01',
+      endDate: '2026-03-10'
+    } as ExistingTrip;
+
+    const setCostData = jest.fn();
+    const setHasUnsavedChanges = jest.fn();
+
+    render(
+      <CostTrackerEditor
+        costData={initialCostData}
+        setCostData={setCostData}
+        onSave={() => undefined}
+        existingTrips={[existingTrip]}
+        selectedTrip={existingTrip}
+        setSelectedTrip={() => undefined}
+        mode="edit"
+        autoSaving={false}
+        setHasUnsavedChanges={setHasUnsavedChanges}
+      />
+    );
+
+    await waitFor(() => expect(setCostData).toHaveBeenCalled());
+
+    const updater = setCostData.mock.calls[0][0] as React.SetStateAction<CostTrackingData>;
+    const updatedCostData =
+      typeof updater === 'function' ? updater(initialCostData) : updater;
+
+    expect(updatedCostData.customCategories).toEqual([
+      'Food',
+      'Local currency held in cash',
+      'Refunds'
+    ]);
+    expect(setHasUnsavedChanges).toHaveBeenCalledWith(true);
+  });
 });

--- a/src/app/admin/components/__tests__/CostTrackerEditor.test.tsx
+++ b/src/app/admin/components/__tests__/CostTrackerEditor.test.tsx
@@ -18,7 +18,9 @@ jest.mock('@/app/admin/components/CostTracking/CountryBudgetManager', () => ({
 
 jest.mock('@/app/admin/components/CostTracking/CategoryManager', () => ({
   __esModule: true,
-  default: () => <div data-testid="category-manager" />
+  default: ({ getCategories }: { getCategories: () => string[] }) => (
+    <div data-testid="category-manager">{getCategories().join('|')}</div>
+  )
 }));
 
 jest.mock('@/app/admin/components/CostTracking/CostSummaryDashboard', () => ({
@@ -172,5 +174,57 @@ describe('CostTrackerEditor', () => {
 
     expect(screen.getByTestId('refund-count')).toHaveTextContent('1');
     expect(screen.getByTestId('fee-count')).toHaveTextContent('1');
+  });
+
+  it('keeps refund categories in the managed category list for legacy custom categories', () => {
+    const sourceExpense = createCashSourceExpense({
+      id: 'cash-source-cop',
+      date: new Date('2026-03-01T00:00:00.000Z'),
+      baseAmount: 20,
+      localAmount: 61000,
+      localCurrency: 'COP',
+      trackingCurrency: 'EUR',
+      country: 'Colombia',
+      description: 'ATM withdrawal'
+    });
+
+    const initialCostData: CostTrackingData = {
+      id: 'cost-1',
+      tripId: '',
+      tripTitle: 'Test Trip',
+      tripStartDate: new Date('2026-03-01T00:00:00.000Z'),
+      tripEndDate: new Date('2026-03-10T00:00:00.000Z'),
+      overallBudget: 1000,
+      currency: 'EUR',
+      countryBudgets: [],
+      expenses: [sourceExpense],
+      customCategories: ['Food'],
+      createdAt: '2026-03-01T00:00:00.000Z'
+    };
+
+    const existingTrip = {
+      id: 'trip-1',
+      title: 'Test Trip',
+      startDate: '2026-03-01',
+      endDate: '2026-03-10'
+    } as ExistingTrip;
+
+    render(
+      <CostTrackerEditor
+        costData={initialCostData}
+        setCostData={() => undefined}
+        onSave={() => undefined}
+        existingTrips={[existingTrip]}
+        selectedTrip={existingTrip}
+        setSelectedTrip={() => undefined}
+        mode="create"
+        autoSaving={false}
+        setHasUnsavedChanges={() => undefined}
+      />
+    );
+
+    expect(screen.getByTestId('category-manager')).toHaveTextContent('Food');
+    expect(screen.getByTestId('category-manager')).toHaveTextContent('Local currency held in cash');
+    expect(screen.getByTestId('category-manager')).toHaveTextContent('Refunds');
   });
 });

--- a/src/app/lib/costUtils.ts
+++ b/src/app/lib/costUtils.ts
@@ -749,9 +749,9 @@ export function isManagedExpenseCategory(category: string): boolean {
 }
 
 export function ensureManagedExpenseCategories(categories: readonly string[]): string[] {
-  const managedCategories = new Set(categories);
-  MANAGED_EXPENSE_CATEGORIES.forEach(category => managedCategories.add(category));
-  return Array.from(managedCategories);
+  const allCategories = new Set(categories);
+  MANAGED_EXPENSE_CATEGORIES.forEach(category => allCategories.add(category));
+  return Array.from(allCategories);
 }
 
 export const EXPENSE_CATEGORIES = [

--- a/src/app/lib/costUtils.ts
+++ b/src/app/lib/costUtils.ts
@@ -742,6 +742,17 @@ export function calculateDailySpendingTrend(expenses: Expense[]): { date: string
  */
 export const CASH_CATEGORY_NAME = 'Local currency held in cash';
 export const REFUNDS_CATEGORY_NAME = 'Refunds';
+export const MANAGED_EXPENSE_CATEGORIES = [CASH_CATEGORY_NAME, REFUNDS_CATEGORY_NAME] as const;
+
+export function isManagedExpenseCategory(category: string): boolean {
+  return MANAGED_EXPENSE_CATEGORIES.includes(category as (typeof MANAGED_EXPENSE_CATEGORIES)[number]);
+}
+
+export function ensureManagedExpenseCategories(categories: readonly string[]): string[] {
+  const managedCategories = new Set(categories);
+  MANAGED_EXPENSE_CATEGORIES.forEach(category => managedCategories.add(category));
+  return Array.from(managedCategories);
+}
 
 export const EXPENSE_CATEGORIES = [
   'Accommodation',
@@ -754,7 +765,7 @@ export const EXPENSE_CATEGORIES = [
   'Medical',
   'Entertainment',
   'Miscellaneous',
-  CASH_CATEGORY_NAME
+  ...MANAGED_EXPENSE_CATEGORIES
 ] as const;
 
 /**


### PR DESCRIPTION
## Summary
- treat Refunds as a managed expense category alongside cash
- repair legacy custom category lists when the editor loads
- prevent managed categories from being manually added, renamed, or deleted
- add focused tests for default and legacy category behavior

## Validation
- bun run test:unit -- src/app/__tests__/utils.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run test:unit -- src/app/admin/components/__tests__/CostTrackerEditor.test.tsx --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential issue where required expense categories (cash and refunds) could be missing from the system.

* **Improvements**
  * Enhanced category management interface to clearly mark required categories and prevent accidental deletion or modification.
  * Improved category preservation to ensure custom categories remain intact when system-required categories are restored.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->