### PR TITLE
Preserve balances when deleting cash sources

### DIFF
--- a/src/app/__tests__/unit/cashTransactions.test.ts
+++ b/src/app/__tests__/unit/cashTransactions.test.ts
@@ -6,6 +6,7 @@ import {
   createCashRefundToBase,
   createCashSourceExpense,
   getCashSourceDateEditConflict,
+  removeCashSourceAndLinkedAllocations,
   restoreAllocationSegmentsOnSources
 } from '@/app/lib/cashTransactions';
 import { CASH_CATEGORY_NAME, REFUNDS_CATEGORY_NAME } from '@/app/lib/costUtils';
@@ -211,6 +212,57 @@ describe('cash transaction utilities', () => {
 
     expect(restored[0].cashTransaction.remainingLocalAmount).toBeCloseTo(17000, 5);
     expect(restored[1].cashTransaction.remainingLocalAmount).toBeCloseTo(20000, 5);
+  });
+
+  test('removing a source restores deleted multi-source allocation balances on remaining sources', () => {
+    const firstSource = createCashSourceExpense({
+      id: 'cash-source-delete-1',
+      date: baseDate,
+      baseAmount: 10,
+      localAmount: 10000,
+      localCurrency: 'ARS',
+      trackingCurrency: 'EUR',
+      country: 'Argentina'
+    });
+
+    const secondSource = createCashSourceExpense({
+      id: 'cash-source-delete-2',
+      date: localDay('2024-01-02'),
+      baseAmount: 20,
+      localAmount: 20000,
+      localCurrency: 'ARS',
+      trackingCurrency: 'EUR',
+      country: 'Argentina'
+    });
+
+    const { expense: allocationExpense, segments } = createCashAllocationExpense({
+      id: 'cash-allocation-delete-1',
+      sources: [firstSource, secondSource],
+      localAmount: 15000,
+      date: localDay('2024-01-03'),
+      trackingCurrency: 'EUR',
+      category: 'Food & Dining'
+    });
+
+    const spentSources = applyAllocationSegmentsToSources(
+      [firstSource, secondSource],
+      segments,
+      allocationExpense.id
+    );
+
+    expect(spentSources[0].cashTransaction.remainingLocalAmount).toBeCloseTo(0, 5);
+    expect(spentSources[1].cashTransaction.remainingLocalAmount).toBeCloseTo(15000, 5);
+    expect(spentSources[1].cashTransaction.allocationIds).toContain(allocationExpense.id);
+
+    const remainingExpenses = removeCashSourceAndLinkedAllocations(
+      [...spentSources, allocationExpense],
+      firstSource.id
+    );
+
+    expect(remainingExpenses.map(expense => expense.id)).toEqual([secondSource.id]);
+    expect(remainingExpenses[0].cashTransaction?.remainingLocalAmount).toBeCloseTo(20000, 5);
+    expect(remainingExpenses[0].cashTransaction?.remainingBaseAmount).toBeCloseTo(20, 5);
+    expect(remainingExpenses[0].cashTransaction?.allocationIds).not.toContain(allocationExpense.id);
   });
 
   test('cash allocation uses remaining balances when spanning multiple exchanges', () => {

--- a/src/app/admin/components/CostTracking/ExpenseManager.tsx
+++ b/src/app/admin/components/CostTracking/ExpenseManager.tsx
@@ -14,6 +14,7 @@ import {
   getAllocationsForSource,
   isCashAllocation,
   isCashSource,
+  removeCashSourceAndLinkedAllocations,
   restoreAllocationSegmentsOnSources
 } from '@/app/lib/cashTransactions';
 import ExpenseForm from '@/app/admin/components/ExpenseForm';
@@ -308,8 +309,8 @@ export default function ExpenseManager({
         }
       }
 
+      const updatedExpenses = removeCashSourceAndLinkedAllocations(costData.expenses, expense.id);
       const removalIds = new Set<string>([expense.id, ...linkedAllocations.map(allocation => allocation.id)]);
-      const updatedExpenses = costData.expenses.filter(item => !removalIds.has(item.id));
 
       setCostData(prev => ({ ...prev, expenses: updatedExpenses }));
       setHasUnsavedChanges(true);

--- a/src/app/lib/cashTransactions.ts
+++ b/src/app/lib/cashTransactions.ts
@@ -10,6 +10,8 @@ import { formatLocalDateLabel, getLocalDateSortValue } from './localDateUtils';
 
 const CURRENCY_EPSILON = 0.000001;
 
+type CashAllocationExpense = Expense & { cashTransaction: CashTransactionAllocationDetails };
+
 export function roundCurrency(value: number, precision: number = 2): number {
   const factor = Math.pow(10, precision);
   return Math.round((value + Number.EPSILON) * factor) / factor;
@@ -582,10 +584,30 @@ export function getCashSourceUsages(
  * @param sourceId - The id of the cash source to match in allocation segments
  * @returns All allocation expenses that contain at least one segment with `sourceExpenseId` equal to `sourceId`
  */
-export function getAllocationsForSource(expenses: Expense[], sourceId: string): Expense[] {
+export function getAllocationsForSource(expenses: Expense[], sourceId: string): CashAllocationExpense[] {
   return expenses
     .filter(isCashAllocation)
     .filter(expense => getAllocationSegments(expense.cashTransaction).some(segment => segment.sourceExpenseId === sourceId));
+}
+
+export function removeCashSourceAndLinkedAllocations(expenses: Expense[], sourceId: string): Expense[] {
+  const source = expenses.find(expense => expense.id === sourceId);
+  if (!isCashSource(source)) {
+    return expenses;
+  }
+
+  const linkedAllocations = getAllocationsForSource(expenses, sourceId);
+  const restoredExpenses = linkedAllocations.reduce((currentExpenses, allocation) => {
+    const segments = getAllocationSegments(allocation.cashTransaction);
+    return restoreAllocationSegmentsOnSources(currentExpenses, segments, allocation.id);
+  }, expenses);
+
+  const removalIds = new Set<string>([
+    sourceId,
+    ...linkedAllocations.map(allocation => allocation.id)
+  ]);
+
+  return restoredExpenses.filter(expense => !removalIds.has(expense.id));
 }
 
 export function getCashSourceDateEditConflict(


### PR DESCRIPTION
## Summary
- restore linked cash allocation segments before deleting a cash source
- remove the deleted source and linked allocation rows through a shared helper
- add a regression test for multi-source allocation balance restoration

## Validation
- bun run test:unit -- src/app/__tests__/unit/cashTransactions.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint