### PR TITLE
Preserve negative shared refund splits

### DIFF
--- a/src/app/__tests__/lib/expenseTravelLookup.test.ts
+++ b/src/app/__tests__/lib/expenseTravelLookup.test.ts
@@ -388,6 +388,30 @@ describe('calculateSplitAmount', () => {
     expect(calculateSplitAmount(expenseAmount, links[2], links)).toBe(35);
   });
 
+  it('splits negative refund amounts across equal links', () => {
+    const expenseAmount = -100;
+    const links: CostTrackingLink[] = [
+      { expenseId: 'refund', splitMode: 'equal' },
+      { expenseId: 'refund', splitMode: 'equal' }
+    ];
+
+    expect(calculateSplitAmount(expenseAmount, links[0], links)).toBe(-50);
+    expect(calculateSplitAmount(expenseAmount, links[1], links)).toBe(-50);
+  });
+
+  it('splits remaining negative refund amount after explicit allocations', () => {
+    const expenseAmount = -100;
+    const links: CostTrackingLink[] = [
+      { expenseId: 'refund', splitMode: 'fixed', splitValue: -30 },
+      { expenseId: 'refund', splitMode: 'equal' },
+      { expenseId: 'refund', splitMode: 'equal' }
+    ];
+
+    expect(calculateSplitAmount(expenseAmount, links[0], links)).toBe(-30);
+    expect(calculateSplitAmount(expenseAmount, links[1], links)).toBe(-35);
+    expect(calculateSplitAmount(expenseAmount, links[2], links)).toBe(-35);
+  });
+
   it('clamps equal-share remainder to 0 when explicit allocations exceed total', () => {
     const expenseAmount = 100;
     const links: CostTrackingLink[] = [
@@ -396,6 +420,17 @@ describe('calculateSplitAmount', () => {
     ];
 
     expect(calculateSplitAmount(expenseAmount, links[0], links)).toBe(110);
+    expect(calculateSplitAmount(expenseAmount, links[1], links)).toBe(0);
+  });
+
+  it('clamps negative equal-share remainder to 0 when explicit allocations exceed refund total', () => {
+    const expenseAmount = -100;
+    const links: CostTrackingLink[] = [
+      { expenseId: 'refund', splitMode: 'fixed', splitValue: -110 },
+      { expenseId: 'refund', splitMode: 'equal' }
+    ];
+
+    expect(calculateSplitAmount(expenseAmount, links[0], links)).toBe(-110);
     expect(calculateSplitAmount(expenseAmount, links[1], links)).toBe(0);
   });
 });

--- a/src/app/admin/components/__tests__/LinkedExpensesDisplay.test.tsx
+++ b/src/app/admin/components/__tests__/LinkedExpensesDisplay.test.tsx
@@ -234,6 +234,63 @@ describe('LinkedExpensesDisplay', () => {
     });
   });
 
+  it('should display allocated negative refund amount for equal multi-link expenses', async () => {
+    mockUseExpenses.mockReturnValue({
+      expenses: [
+        {
+          id: 'refund-1',
+          date: '2024-01-04',
+          amount: -100,
+          currency: 'EUR',
+          category: 'Food',
+          country: 'France',
+          description: 'Shared dinner refund',
+          expenseType: 'actual'
+        }
+      ],
+      isLoading: false,
+      isError: undefined,
+      mutate: jest.fn(),
+    });
+
+    mockUseExpenseLinks.mockReturnValue({
+      expenseLinks: [
+        {
+          expenseId: 'refund-1',
+          travelItemId: 'route-1',
+          travelItemName: 'A → B',
+          travelItemType: 'route',
+          splitMode: 'equal'
+        },
+        {
+          expenseId: 'refund-1',
+          travelItemId: 'location-1',
+          travelItemName: 'Test Location',
+          travelItemType: 'location',
+          splitMode: 'equal'
+        }
+      ],
+      isLoading: false,
+      isError: undefined,
+      mutate: jest.fn()
+    });
+
+    render(
+      <LinkedExpensesDisplay
+        itemId="location-1"
+        itemType="location"
+        tripId={mockTripId}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('💰 Linked Expenses (1)')).toBeInTheDocument();
+      expect(screen.getByText('Total: EUR -50.00')).toBeInTheDocument();
+      expect(screen.getByText('Shared dinner refund')).toBeInTheDocument();
+      expect(screen.getByText('EUR -50.00')).toBeInTheDocument();
+    });
+  });
+
   it('should not render when no expenses are linked', async () => {
     mockUseExpenseLinks.mockReturnValue({
       expenseLinks: [],

--- a/src/app/lib/expenseTravelLookup.ts
+++ b/src/app/lib/expenseTravelLookup.ts
@@ -353,7 +353,10 @@ export function calculateSplitAmount(
   }, 0);
 
   const equalCount = normalizedModes.filter(mode => mode === 'equal').length;
-  const remainder = Math.max(expenseAmount - explicitSum, 0);
+  const rawRemainder = expenseAmount - explicitSum;
+  const remainder = expenseAmount < 0
+    ? Math.min(rawRemainder, 0)
+    : Math.max(rawRemainder, 0);
   const equalShare = equalCount > 0 ? remainder / equalCount : 0;
 
   const mode = link.splitMode ?? 'equal';


### PR DESCRIPTION
## Summary
- make equal split remainder clamping sign-aware so shared refunds stay negative
- cover equal negative refunds and mixed explicit/equal negative splits in allocator tests
- add linked-expense UI regression coverage for displayed allocated refund totals

## Validation
- bun run test:unit -- src/app/__tests__/lib/expenseTravelLookup.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run test:unit -- src/app/admin/components/__tests__/LinkedExpensesDisplay.test.tsx --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint