### PR TITLE
Reject invalid YNAB calendar dates

### DIFF
--- a/src/app/__tests__/lib/ynabUtils.test.ts
+++ b/src/app/__tests__/lib/ynabUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from '@jest/globals';
-import { filterNewTransactions, updateLastImportedTransaction, findLatestTransaction } from '@/app/lib/ynabUtils';
+import { convertYnabDateToISO, filterNewTransactions, updateLastImportedTransaction, findLatestTransaction } from '@/app/lib/ynabUtils';
 import { ProcessedYnabTransaction, YnabImportData } from '@/app/types';
 
 // Mock data helpers
@@ -35,6 +35,26 @@ const createMockTransactions = (): ProcessedYnabTransaction[] => [
 ];
 
 describe('YNAB Transaction Filtering', () => {
+  describe('convertYnabDateToISO', () => {
+    it('converts valid YNAB dates to ISO dates', () => {
+      expect(convertYnabDateToISO('5/7/2025')).toBe('2025-07-05');
+      expect(convertYnabDateToISO('29/02/2024')).toBe('2024-02-29');
+    });
+
+    it('rejects impossible calendar dates instead of normalizing them', () => {
+      expect(convertYnabDateToISO('31/02/2025')).toBe('');
+      expect(convertYnabDateToISO('29/02/2025')).toBe('');
+      expect(convertYnabDateToISO('31/04/2025')).toBe('');
+    });
+
+    it('rejects malformed or out-of-range dates', () => {
+      expect(convertYnabDateToISO('')).toBe('');
+      expect(convertYnabDateToISO('2025-07-05')).toBe('');
+      expect(convertYnabDateToISO('00/07/2025')).toBe('');
+      expect(convertYnabDateToISO('05/13/2025')).toBe('');
+    });
+  });
+
   describe('filterNewTransactions', () => {
     it('should return all transactions when no last imported hash provided', () => {
       const transactions = createMockTransactions();

--- a/src/app/__tests__/lib/ynabUtils.test.ts
+++ b/src/app/__tests__/lib/ynabUtils.test.ts
@@ -39,6 +39,7 @@ describe('YNAB Transaction Filtering', () => {
     it('converts valid YNAB dates to ISO dates', () => {
       expect(convertYnabDateToISO('5/7/2025')).toBe('2025-07-05');
       expect(convertYnabDateToISO('29/02/2024')).toBe('2024-02-29');
+      expect(convertYnabDateToISO('1/1/0001')).toBe('0001-01-01');
     });
 
     it('rejects impossible calendar dates instead of normalizing them', () => {

--- a/src/app/lib/ynabUtils.ts
+++ b/src/app/lib/ynabUtils.ts
@@ -72,6 +72,7 @@ export function convertYnabDateToISO(ynabDate: string): string {
   }
 
   const parsedDate = new Date(Date.UTC(yearNum, monthNum - 1, dayNum));
+  parsedDate.setUTCFullYear(yearNum);
   if (
     parsedDate.getUTCFullYear() !== yearNum ||
     parsedDate.getUTCMonth() !== monthNum - 1 ||
@@ -84,7 +85,7 @@ export function convertYnabDateToISO(ynabDate: string): string {
   const paddedDay = String(dayNum).padStart(2, '0');
   const paddedMonth = String(monthNum).padStart(2, '0');
   
-  return `${yearNum}-${paddedMonth}-${paddedDay}`;
+  return `${year}-${paddedMonth}-${paddedDay}`;
 }
 
 export function parseYnabFile(fileContent: string): YnabParseResult {

--- a/src/app/lib/ynabUtils.ts
+++ b/src/app/lib/ynabUtils.ts
@@ -71,9 +71,18 @@ export function convertYnabDateToISO(ynabDate: string): string {
     return '';
   }
 
+  const parsedDate = new Date(Date.UTC(yearNum, monthNum - 1, dayNum));
+  if (
+    parsedDate.getUTCFullYear() !== yearNum ||
+    parsedDate.getUTCMonth() !== monthNum - 1 ||
+    parsedDate.getUTCDate() !== dayNum
+  ) {
+    return '';
+  }
+
   // Pad with zeros and return in ISO format
-  const paddedDay = day.padStart(2, '0');
-  const paddedMonth = month.padStart(2, '0');
+  const paddedDay = String(dayNum).padStart(2, '0');
+  const paddedMonth = String(monthNum).padStart(2, '0');
   
   return `${yearNum}-${paddedMonth}-${paddedDay}`;
 }
@@ -281,10 +290,8 @@ export function findLatestTransaction(
   transactions: ProcessedYnabTransaction[]
 ): ProcessedYnabTransaction | null {
   if (transactions.length === 0) return null;
-  
+
   return transactions.reduce((latest, current) => {
     return new Date(current.date) > new Date(latest.date) ? current : latest;
   });
 }
-
- 


### PR DESCRIPTION
## Summary
- validate converted YNAB DD/MM/YYYY dates against the real calendar before returning ISO strings
- reject impossible month/day combinations instead of producing normalized-looking invalid ISO dates
- add unit coverage for leap-year, impossible-date, and malformed-date cases

Security scan finding: 3c2613efdce48191bab5d10a392860c3

## Validation
- bun run test:unit -- src/app/__tests__/lib/ynabUtils.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint (passes with existing 46-warning baseline)
- bun run build (passes with existing Turbopack trace warnings)