### PR TITLE
Preserve duplicate YNAB import rows

### DIFF
--- a/src/app/__tests__/lib/ynabUtils.test.ts
+++ b/src/app/__tests__/lib/ynabUtils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from '@jest/globals';
-import { convertYnabDateToISO, filterNewTransactions, updateLastImportedTransaction, findLatestTransaction } from '@/app/lib/ynabUtils';
+import {
+  consumeLegacyImportedHash,
+  convertYnabDateToISO,
+  filterNewTransactions,
+  findLatestTransaction,
+  getLegacyImportedHashCounts,
+  updateLastImportedTransaction
+} from '@/app/lib/ynabUtils';
 import { ProcessedYnabTransaction, YnabImportData } from '@/app/types';
 
 // Mock data helpers
@@ -35,6 +42,33 @@ const createMockTransactions = (): ProcessedYnabTransaction[] => [
 ];
 
 describe('YNAB Transaction Filtering', () => {
+  describe('legacy imported transaction counts', () => {
+    const hashA = 'a'.repeat(64);
+    const hashB = 'b'.repeat(64);
+
+    it('counts base hash entries even when instance keys exist for that hash', () => {
+      const counts = getLegacyImportedHashCounts([
+        hashA,
+        `${hashA}-0`,
+        hashB,
+        'not-a-ynab-import-key'
+      ]);
+
+      expect(counts.get(hashA)).toBe(1);
+      expect(counts.get(hashB)).toBe(1);
+    });
+
+    it('consumes one base-hash import at a time', () => {
+      const counts = getLegacyImportedHashCounts([hashA, hashA, `${hashA}-0`]);
+
+      expect(consumeLegacyImportedHash(counts, hashA)).toBe(true);
+      expect(counts.get(hashA)).toBe(1);
+      expect(consumeLegacyImportedHash(counts, hashA)).toBe(true);
+      expect(counts.has(hashA)).toBe(false);
+      expect(consumeLegacyImportedHash(counts, hashA)).toBe(false);
+    });
+  });
+
   describe('convertYnabDateToISO', () => {
     it('converts valid YNAB dates to ISO dates', () => {
       expect(convertYnabDateToISO('5/7/2025')).toBe('2025-07-05');

--- a/src/app/api/cost-tracking/[id]/ynab-process/route.ts
+++ b/src/app/api/cost-tracking/[id]/ynab-process/route.ts
@@ -9,8 +9,15 @@ import {
   ExpenseType,
   YnabTransactionFilterResult
 } from '@/app/types';
-import { createTransactionHash, filterNewTransactions, getTransactionImportKey, updateLastImportedTransaction } from '@/app/lib/ynabUtils';
-import { convertYnabDateToISO } from '@/app/lib/ynabUtils';
+import {
+  consumeLegacyImportedHash,
+  convertYnabDateToISO,
+  createTransactionHash,
+  filterNewTransactions,
+  getLegacyImportedHashCounts,
+  getTransactionImportKey,
+  updateLastImportedTransaction
+} from '@/app/lib/ynabUtils';
 import { cleanupTempFile, cleanupOldTempFiles } from '@/app/lib/ynabServerUtils';
 import { isAdminDomain } from '@/app/lib/server-domains';
 import { createExpenseLinkingService } from '@/app/lib/expenseLinkingService';
@@ -127,11 +134,8 @@ async function handleProcessTransactions(
   const costData = unifiedTrip.costData;
 
   const existingHashes = costData.ynabImportData?.importedTransactionHashes || [];
-  const existingBaseHashes = new Set(
-    existingHashes
-      .map((value: string) => value.match(/^([0-9a-f]{64})(?:-\d+)?$/i)?.[1])
-      .filter((value: string | undefined): value is string => Boolean(value))
-  );
+  const existingHashSet = new Set(existingHashes);
+  const legacyImportedHashCounts = getLegacyImportedHashCounts(existingHashes);
   const lastImportedHash = costData.ynabImportData?.lastImportedTransactionHash;
 
   // Process transactions based on mappings
@@ -147,7 +151,9 @@ async function handleProcessTransactions(
 
     const hash = createTransactionHash(transaction);
     const instanceId = `${hash}-${index}`;
-    const isAlreadyImported = existingHashes.includes(instanceId) || existingBaseHashes.has(hash);
+    const hasImportedInstance = existingHashSet.has(instanceId);
+    const hasLegacyImportedHash = consumeLegacyImportedHash(legacyImportedHashCounts, hash);
+    const isAlreadyImported = hasImportedInstance || hasLegacyImportedHash;
 
     const mapping = mappings.find(m => m.ynabCategory === transaction.Category);
     if (!mapping || mapping.mappingType === 'none') continue; // Skip 'none' mappings
@@ -315,24 +321,24 @@ async function handleImportTransactions(
   const usedIndexes = new Set<number>();
   const importedTrackingKeys = costData.ynabImportData.importedTransactionHashes ?? [];
   const importedKeySet = new Set(importedTrackingKeys);
-  const importedBaseHashSet = new Set(
-    importedTrackingKeys
-      .map((value: string) => value.match(/^([0-9a-f]{64})(?:-\d+)?$/i)?.[1])
-      .filter((value: string | undefined): value is string => Boolean(value))
-  );
+  const legacyImportedHashCounts = getLegacyImportedHashCounts(importedTrackingKeys);
   const newKeySet = new Set<string>();
-  const newBaseHashSet = new Set<string>();
   const linkOperations: Array<{ expenseId: string; travelLinkInfo: TravelLinkInfo }> = [];
 
   for (const selectedTxn of selectedTransactions) {
     const { transactionHash, transactionId, transactionSourceIndex, expenseCategory, travelLinkInfo } = selectedTxn;
     const targetIndex = typeof transactionSourceIndex === 'number' ? transactionSourceIndex : undefined;
 
-    if (
-      importedBaseHashSet.has(transactionHash) ||
-      newBaseHashSet.has(transactionHash) ||
-      (transactionId ? importedKeySet.has(transactionId) || newKeySet.has(transactionId) : false)
-    ) {
+    if (transactionId && importedKeySet.has(transactionId)) {
+      consumeLegacyImportedHash(legacyImportedHashCounts, transactionHash);
+      continue;
+    }
+
+    if (transactionId && newKeySet.has(transactionId)) {
+      continue;
+    }
+
+    if (consumeLegacyImportedHash(legacyImportedHashCounts, transactionHash)) {
       continue;
     }
 
@@ -448,7 +454,6 @@ async function handleImportTransactions(
     newExpenses.push(expense);
     importedTransactions.push(processedTxn);
     newKeySet.add(importKey);
-    newBaseHashSet.add(transactionHash);
     if (travelLinkInfo) {
       linkOperations.push({ expenseId: expense.id, travelLinkInfo });
     }

--- a/src/app/lib/ynabUtils.ts
+++ b/src/app/lib/ynabUtils.ts
@@ -28,6 +28,37 @@ export function getTransactionImportKey(
   return transaction.hash;
 }
 
+const YNAB_IMPORT_KEY_PATTERN = /^([0-9a-f]{64})(?:-(\d+))?$/i;
+
+export function getLegacyImportedHashCounts(importKeys: string[]): Map<string, number> {
+  const legacyCounts = new Map<string, number>();
+  for (const importKey of importKeys) {
+    const match = importKey.match(YNAB_IMPORT_KEY_PATTERN);
+    if (!match?.[1] || match[2] !== undefined) {
+      continue;
+    }
+
+    legacyCounts.set(match[1], (legacyCounts.get(match[1]) ?? 0) + 1);
+  }
+
+  return legacyCounts;
+}
+
+export function consumeLegacyImportedHash(legacyCounts: Map<string, number>, hash: string): boolean {
+  const remaining = legacyCounts.get(hash) ?? 0;
+  if (remaining <= 0) {
+    return false;
+  }
+
+  if (remaining === 1) {
+    legacyCounts.delete(hash);
+  } else {
+    legacyCounts.set(hash, remaining - 1);
+  }
+
+  return true;
+}
+
 /**
  * Produces a deterministic fingerprint for a YNAB transaction used for deduplication.
  *


### PR DESCRIPTION
## Summary
- stop treating a content hash as meaning every identical YNAB row has already been imported
- keep legacy base-hash compatibility by consuming one legacy match at a time
- add unit coverage for legacy base hash counting and consumption

Security scan finding: df4258c3d92c8191a09d7c527895e045

## Validation
- bun run test:unit -- src/app/__tests__/lib/ynabUtils.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint (passes with existing 46-warning baseline)
- bun run build (passes with existing Turbopack trace warnings)