### PR TITLE
Anchor YNAB filtering before duplicate removal

### DIFF
--- a/src/app/__tests__/lib/ynabUtils.test.ts
+++ b/src/app/__tests__/lib/ynabUtils.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from '@jest/globals';
 import {
   consumeLegacyImportedHash,
   convertYnabDateToISO,
+  filterAvailableTransactionsAfterLastImport,
   filterNewTransactions,
   findLatestTransaction,
   getLegacyImportedHashCounts,
+  getTransactionImportKey,
   updateLastImportedTransaction
 } from '@/app/lib/ynabUtils';
 import { ProcessedYnabTransaction, YnabImportData } from '@/app/types';
@@ -175,6 +177,51 @@ describe('YNAB Transaction Filtering', () => {
       // Should return hash4 and hash5 (after hash3 chronologically)
       expect(result.newTransactions[0].hash).toBe('hash4');
       expect(result.newTransactions[1].hash).toBe('hash5');
+    });
+  });
+
+  describe('filterAvailableTransactionsAfterLastImport', () => {
+    it('finds the last imported anchor in the full processed list even when it is not available', () => {
+      const processedTransactions = createMockTransactions().map((transaction, index) => ({
+        ...transaction,
+        sourceIndex: index
+      }));
+      const availableImportKeys = new Set(
+        processedTransactions
+          .filter(transaction => transaction.hash === 'hash4' || transaction.hash === 'hash5')
+          .map(transaction => getTransactionImportKey(transaction))
+      );
+
+      const result = filterAvailableTransactionsAfterLastImport(
+        processedTransactions,
+        availableImportKeys,
+        'hash3'
+      );
+
+      expect(result.lastTransactionFound).toBe(true);
+      expect(result.newTransactions.map(transaction => transaction.hash)).toEqual(['hash4', 'hash5']);
+      expect(result.filteredCount).toBe(3);
+    });
+
+    it('returns all available transactions when the last imported anchor is missing', () => {
+      const processedTransactions = createMockTransactions().map((transaction, index) => ({
+        ...transaction,
+        sourceIndex: index
+      }));
+      const availableImportKeys = new Set([
+        getTransactionImportKey(processedTransactions[1]),
+        getTransactionImportKey(processedTransactions[3])
+      ]);
+
+      const result = filterAvailableTransactionsAfterLastImport(
+        processedTransactions,
+        availableImportKeys,
+        'missing-hash'
+      );
+
+      expect(result.lastTransactionFound).toBe(false);
+      expect(result.newTransactions.map(transaction => transaction.hash)).toEqual(['hash2', 'hash4']);
+      expect(result.filteredCount).toBe(3);
     });
   });
 

--- a/src/app/api/cost-tracking/[id]/ynab-process/route.ts
+++ b/src/app/api/cost-tracking/[id]/ynab-process/route.ts
@@ -13,7 +13,7 @@ import {
   consumeLegacyImportedHash,
   convertYnabDateToISO,
   createTransactionHash,
-  filterNewTransactions,
+  filterAvailableTransactionsAfterLastImport,
   getLegacyImportedHashCounts,
   getTransactionImportKey,
   updateLastImportedTransaction
@@ -141,6 +141,7 @@ async function handleProcessTransactions(
   // Process transactions based on mappings
   const processedTransactions: ProcessedYnabTransaction[] = [];
   const uniqueTransactions: ProcessedYnabTransaction[] = [];
+  const uniqueTransactionKeys = new Set<string>();
   let alreadyImportedCount = 0;
   const mappedCategories = new Set(mappings.map(m => m.ynabCategory));
 
@@ -189,6 +190,7 @@ async function handleProcessTransactions(
     // Only include if not already imported
     if (!isAlreadyImported) {
       uniqueTransactions.push(processedTxn);
+      uniqueTransactionKeys.add(getTransactionImportKey(processedTxn));
     } else {
       alreadyImportedCount += 1;
     }
@@ -213,9 +215,12 @@ async function handleProcessTransactions(
       lastTransactionFound: false
     };
   } else if (lastImportedHash) {
-    // Apply chronological filtering to `uniqueTransactions` (hash-based filtering already removed previously imported items).
-    filteredResult = filterNewTransactions(uniqueTransactions, lastImportedHash);
-    filteredCount += filteredResult.filteredCount;
+    filteredResult = filterAvailableTransactionsAfterLastImport(
+      processedTransactions,
+      uniqueTransactionKeys,
+      lastImportedHash
+    );
+    filteredCount = filteredResult.filteredCount;
   } else {
     filteredResult = {
       newTransactions: uniqueTransactions,

--- a/src/app/lib/ynabUtils.ts
+++ b/src/app/lib/ynabUtils.ts
@@ -266,6 +266,33 @@ export function filterNewTransactions(
   };
 }
 
+export function filterAvailableTransactionsAfterLastImport(
+  processedTransactions: ProcessedYnabTransaction[],
+  availableImportKeys: Set<string>,
+  lastImportedHash?: string
+): YnabTransactionFilterResult {
+  if (!lastImportedHash) {
+    return {
+      newTransactions: processedTransactions.filter(transaction =>
+        availableImportKeys.has(getTransactionImportKey(transaction))
+      ),
+      filteredCount: processedTransactions.length - availableImportKeys.size,
+      lastTransactionFound: false
+    };
+  }
+
+  const chronologicalResult = filterNewTransactions(processedTransactions, lastImportedHash);
+  const newTransactions = chronologicalResult.newTransactions.filter(transaction =>
+    availableImportKeys.has(getTransactionImportKey(transaction))
+  );
+
+  return {
+    ...chronologicalResult,
+    newTransactions,
+    filteredCount: processedTransactions.length - newTransactions.length
+  };
+}
+
 /**
  * Update import tracking to reflect newly imported transactions.
  *


### PR DESCRIPTION
## Summary
- anchor last-import filtering against the full processed upload before duplicate/import-key removal
- return only transactions still available for import after the chronological anchor is applied
- add unit coverage for the anchor-present-but-unavailable failure mode

Security scan finding: 34ec15ba4be4819190e045b6cefd0d41

## Validation
- bun run test:unit -- src/app/__tests__/lib/ynabUtils.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint (passes with existing 46-warning baseline)
- bun run build (passes with existing Turbopack trace warnings)