### PR TITLE
Include date-only timing in itinerary exports

### DIFF
--- a/src/app/__tests__/lib/itineraryExport.test.ts
+++ b/src/app/__tests__/lib/itineraryExport.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from '@jest/globals';
+import { formatLocationTimingForExport } from '@/app/lib/itineraryExport';
+
+describe('formatLocationTimingForExport', () => {
+  it('keeps non-redundant date-only arrival and departure values', () => {
+    expect(formatLocationTimingForExport({
+      arrivalTime: '2026-04-03',
+      departureTime: '2026-04-06',
+      startDay: '2026-04-02',
+      endDay: '2026-04-05'
+    })).toBe('arrive 2026-04-03 / depart 2026-04-06');
+  });
+
+  it('omits date-only values that only repeat the location range', () => {
+    expect(formatLocationTimingForExport({
+      arrivalTime: '2026-04-02',
+      departureTime: '2026-04-05',
+      startDay: '2026-04-02',
+      endDay: '2026-04-05'
+    })).toBe('');
+  });
+
+  it('keeps clock and timestamp values even when they fall on the location range dates', () => {
+    expect(formatLocationTimingForExport({
+      arrivalTime: '09:30',
+      departureTime: '2026-04-05T18:45:00.000Z',
+      startDay: '2026-04-02',
+      endDay: '2026-04-05'
+    })).toBe('arrive 09:30 / depart 2026-04-05T18:45:00.000Z');
+  });
+});

--- a/src/app/admin/edit/[tripId]/page.tsx
+++ b/src/app/admin/edit/[tripId]/page.tsx
@@ -7,6 +7,7 @@ import { formatDateRange } from '@/app/lib/dateUtils';
 import { formatDate } from '@/app/lib/costUtils';
 import { calculateExpenseTotalsByLocation } from '@/app/lib/expenseTravelLookup';
 import { combineAccommodationDescriptions } from '@/app/lib/combineAccommodationDescriptions';
+import { formatLocationTimingForExport } from '@/app/lib/itineraryExport';
 import { formatLocalDateInput, getLocalDateSortValue } from '@/app/lib/localDateUtils';
 import DeleteWarningDialog from '@/app/admin/components/DeleteWarningDialog';
 import ReassignmentDialog from '@/app/admin/components/ReassignmentDialog';
@@ -328,22 +329,12 @@ export default function TripEditorPage() {
         if (location.arrivalTime || location.departureTime) {
           const startDay = formatLocalDateInput(location.date);
           const endDay = formatLocalDateInput(location.endDate) || startDay;
-          const isDateOnly = (value: string) => /^\d{4}-\d{2}-\d{2}$/.test(value);
-          const isTimeOfDay = (value: string) => value.includes(':');
-
-          const arrivalValue = location.arrivalTime || '';
-          const departureValue = location.departureTime || '';
-          const arrivalIsRedundantDate = arrivalValue && isDateOnly(arrivalValue) && arrivalValue === startDay;
-          const departureIsRedundantDate = departureValue && isDateOnly(departureValue) && departureValue === endDay;
-
-          const timing = [
-            arrivalValue && (isTimeOfDay(arrivalValue) || (!isDateOnly(arrivalValue) && !arrivalIsRedundantDate))
-              ? `arrive ${arrivalValue}`
-              : null,
-            departureValue && (isTimeOfDay(departureValue) || (!isDateOnly(departureValue) && !departureIsRedundantDate))
-              ? `depart ${departureValue}`
-              : null
-          ].filter(Boolean).join(' / ');
+          const timing = formatLocationTimingForExport({
+            arrivalTime: location.arrivalTime,
+            departureTime: location.departureTime,
+            startDay,
+            endDay
+          });
           if (timing) {
             lines.push(`   - Timing: ${timing}`);
           }

--- a/src/app/lib/itineraryExport.ts
+++ b/src/app/lib/itineraryExport.ts
@@ -1,0 +1,41 @@
+type LocationTimingExportInput = {
+  arrivalTime?: string | null;
+  departureTime?: string | null;
+  startDay: string;
+  endDay: string;
+};
+
+const isDateOnlyValue = (value: string): boolean => /^\d{4}-\d{2}-\d{2}$/.test(value);
+
+const isTimeOfDayValue = (value: string): boolean => value.includes(':');
+
+const shouldIncludeTimingValue = (value: string, redundantDate: string): boolean => {
+  if (!value) {
+    return false;
+  }
+
+  if (isTimeOfDayValue(value)) {
+    return true;
+  }
+
+  if (isDateOnlyValue(value)) {
+    return value !== redundantDate;
+  }
+
+  return true;
+};
+
+export function formatLocationTimingForExport({
+  arrivalTime,
+  departureTime,
+  startDay,
+  endDay
+}: LocationTimingExportInput): string {
+  const arrivalValue = arrivalTime || '';
+  const departureValue = departureTime || '';
+
+  return [
+    shouldIncludeTimingValue(arrivalValue, startDay) ? `arrive ${arrivalValue}` : null,
+    shouldIncludeTimingValue(departureValue, endDay) ? `depart ${departureValue}` : null
+  ].filter(Boolean).join(' / ');
+}


### PR DESCRIPTION
## Summary
- preserve non-redundant date-only arrival/departure timing values in the LLM itinerary export
- keep omitting date-only values that only repeat the location start/end range
- extract the timing formatting rule into a focused helper with unit tests

Security scan finding: 6bdb1c00575c81918dee87b7c802cc85

## Validation
- bun run test:unit -- src/app/__tests__/lib/itineraryExport.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint (passes with existing 46-warning baseline)
- bun run build (passes with existing Turbopack trace warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced itinerary export formatting for arrival and departure timing. The system now intelligently omits redundant date values when they align with location dates, while preserving specific times for accurate scheduling information.

* **Tests**
  * Added test coverage for timing export formatting to ensure proper handling of date and time values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->