### PR TITLE
Remove stale React import from map accessibility tests

### DIFF
--- a/src/app/__tests__/accessibility/MapAccessibility.test.tsx
+++ b/src/app/__tests__/accessibility/MapAccessibility.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import MapView from '@/app/components/Map';


### PR DESCRIPTION
## Summary
- remove the unused default React import from MapAccessibility.test.tsx now that tsconfig uses the automatic JSX runtime

## Tests
- bun run test:accessibility -- src/app/__tests__/accessibility/MapAccessibility.test.tsx --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bunx tsc --noEmit --pretty false --incremental false (still fails on existing Jest/jest-axe test typing backlog, but no longer reports the stale React import)
- bun run lint
- bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary imports from test files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bdamokos/travel-tracker/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->