### PR TITLE
Clear travel items after selector load failures

### DIFF
--- a/src/app/admin/components/TravelItemSelector.tsx
+++ b/src/app/admin/components/TravelItemSelector.tsx
@@ -310,6 +310,7 @@ export default function TravelItemSelector({
           return;
         }
         console.error('Error loading travel items:', error);
+        setTravelItems([]);
         if (error instanceof Error && error.name === 'AbortError') {
           setLoadError('Loading travel items timed out. Please try again.');
         } else {

--- a/src/app/admin/components/__tests__/TravelItemSelector.test.tsx
+++ b/src/app/admin/components/__tests__/TravelItemSelector.test.tsx
@@ -175,4 +175,66 @@ describe('TravelItemSelector', () => {
       expect(screen.getByLabelText('Location')).toBeInTheDocument();
     });
   });
+
+  it('clears stale travel items after a later trip load fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          title: 'First Trip',
+          locations: [
+            {
+              id: 'location-1',
+              name: 'Paris',
+              notes: '',
+              date: '2024-01-02'
+            }
+          ],
+          routes: [],
+          accommodations: []
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'server error'
+      } as Response);
+
+    const { rerender } = render(
+      <TravelItemSelector
+        expenseId="expense-1"
+        tripId="first-trip-id"
+        onReferenceChange={mockOnReferenceChange}
+        loadExistingLink={false}
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/travel-data?id=first-trip-id',
+        expect.objectContaining({ signal: expect.anything() })
+      );
+    });
+
+    fireEvent.change(screen.getByLabelText('Link to Travel Item (Optional)'), {
+      target: { value: 'location' }
+    });
+
+    expect(await screen.findByText('Paris - 2024-01-02')).toBeInTheDocument();
+
+    rerender(
+      <TravelItemSelector
+        expenseId="expense-1"
+        tripId="failed-trip-id"
+        onReferenceChange={mockOnReferenceChange}
+        loadExistingLink={false}
+      />
+    );
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load travel items');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Paris - 2024-01-02')).not.toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- clear TravelItemSelector item options when a trip-data reload fails
- add regression coverage for a successful trip load followed by a failed trip reload so stale options cannot remain selectable

## Tests
- bun run test:unit -- src/app/admin/components/__tests__/TravelItemSelector.test.tsx --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint
- bun run build