### PR TITLE
Preserve legacy sub-route transport fallback

### DIFF
--- a/src/app/__tests__/unit/useTripEditor.delete-confirmation.test.ts
+++ b/src/app/__tests__/unit/useTripEditor.delete-confirmation.test.ts
@@ -199,4 +199,67 @@ describe('useTripEditor delete confirmations', () => {
 
     expect(result.current.hasUnsavedChanges).toBe(true);
   });
+
+  it('preserves a legacy parent route transport type for sub-routes missing their own type', async () => {
+    const legacyTrip = {
+      id: 'trip-legacy',
+      title: 'Legacy Trip',
+      description: '',
+      startDate: '2025-01-01',
+      endDate: '2025-01-02',
+      instagramUsername: '',
+      locations: [],
+      routes: [
+        {
+          id: 'route-1',
+          type: 'train',
+          from: 'Paris',
+          to: 'Rome',
+          fromCoords: [48.8566, 2.3522],
+          toCoords: [41.9028, 12.4964],
+          date: '2025-01-02',
+          subRoutes: [
+            {
+              id: 'segment-1',
+              from: 'Paris',
+              to: 'Milan',
+              fromCoords: [48.8566, 2.3522],
+              toCoords: [45.4642, 9.19],
+              date: '2025-01-02'
+            },
+            {
+              id: 'segment-2',
+              from: 'Milan',
+              to: 'Rome',
+              fromCoords: [45.4642, 9.19],
+              toCoords: [41.9028, 12.4964],
+              date: '2025-01-02'
+            }
+          ]
+        }
+      ],
+      accommodations: []
+    };
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => legacyTrip
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({})
+      } as Response);
+
+    const { result } = renderHook(() => useTripEditor('trip-legacy'));
+
+    await waitFor(() => {
+      expect(result.current.travelData.routes).toHaveLength(1);
+    });
+
+    const migratedRoute = result.current.travelData.routes[0];
+    expect(migratedRoute.transportType).toBe('train');
+    expect(migratedRoute.subRoutes?.map(segment => segment.transportType)).toEqual(['train', 'train']);
+  });
 });

--- a/src/app/admin/edit/[tripId]/hooks/useTripEditor.ts
+++ b/src/app/admin/edit/[tripId]/hooks/useTripEditor.ts
@@ -7,7 +7,7 @@ import { Location, InstagramPost, BlogPost, TikTokPost, TravelRoute, TravelRoute
 import { getLinkedExpenses, cleanupExpenseLinks, reassignExpenseLinks, LinkedExpense } from '@/app/lib/costLinkCleanup';
 import { CostTrackingData } from '@/app/types';
 import { ExpenseTravelLookup } from '@/app/lib/expenseTravelLookup';
-import { generateRoutePoints, getCompositeTransportType } from '@/app/lib/routeUtils';
+import { generateRoutePoints, getCompositeTransportType, normalizeTransportationType } from '@/app/lib/routeUtils';
 import { generateId } from '@/app/lib/costUtils';
 import { geocodeLocation as geocodeLocationService } from '@/app/services/geocoding';
 import { getTodayLocalDay, parseDateAsLocalDay } from '@/app/lib/localDateUtils';
@@ -191,11 +191,14 @@ export function useTripEditor(tripId: string | null) {
     })) || [];
 
     // Migrate routes to new format if they don't have IDs
-    const migratedRoutes = tripData.routes?.map((route: Partial<TravelRoute>) => {
+    type LegacyRouteFields = { type?: unknown };
+
+    const migratedRoutes = tripData.routes?.map((route: Partial<TravelRoute> & LegacyRouteFields) => {
       const hasSubRoutes = (route.subRoutes?.length || 0) > 0;
+      const routeLegacyTransportType = normalizeTransportationType(route.transportType ?? route.type, 'car');
       const routeTransportType = hasSubRoutes
-        ? getCompositeTransportType(route.subRoutes ?? [], route.transportType || 'car')
-        : (route.transportType || 'car');
+        ? getCompositeTransportType(route.subRoutes ?? [], routeLegacyTransportType)
+        : routeLegacyTransportType;
 
       return {
         id: route.id || generateId(),
@@ -213,13 +216,16 @@ export function useTripEditor(tripId: string | null) {
         routePoints: route.routePoints, // Preserve existing routePoints
         useManualRoutePoints: route.useManualRoutePoints,
         isReturn: route.isReturn,
-        subRoutes: route.subRoutes?.map((segment: Partial<TravelRouteSegment>) => ({
+        subRoutes: route.subRoutes?.map((segment: Partial<TravelRouteSegment> & LegacyRouteFields) => ({
           id: segment.id || generateId(),
           from: segment.from || '',
           to: segment.to || '',
           fromCoords: segment.fromCoords || [0, 0] as [number, number],
           toCoords: segment.toCoords || [0, 0] as [number, number],
-          transportType: segment.transportType || (routeTransportType !== 'multimodal' ? routeTransportType : undefined) || 'car',
+          transportType: normalizeTransportationType(
+            segment.transportType ?? segment.type,
+            routeLegacyTransportType
+          ),
           date: segment.date
             ? (parseDateAsLocalDay(segment.date) || getTodayLocalDay())
             : (parseDateAsLocalDay(route.date) || getTodayLocalDay()),


### PR DESCRIPTION
## Summary
- keep the parent legacy transport type separate during old-format route migration
- use that parent type as the fallback for sub-routes missing their own transport type
- add regression coverage for legacy train multi-segment routes whose segments have no transportType

## Tests
- bun run test:unit -- src/app/__tests__/unit/useTripEditor.delete-confirmation.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint
- bun run build