### PR TITLE
Fix dominant marker tone counting

### DIFF
--- a/src/app/__tests__/lib/mapIconUtils.test.ts
+++ b/src/app/__tests__/lib/mapIconUtils.test.ts
@@ -1,4 +1,4 @@
-import { createCountMarkerIcon, getMarkerLegendSvgMarkup } from '@/app/lib/mapIconUtils';
+import { createCountMarkerIcon, getDominantMarkerTone, getMarkerLegendSvgMarkup } from '@/app/lib/mapIconUtils';
 
 describe('getMarkerLegendSvgMarkup', () => {
   it('renders past marker legend SVG with expected tone styling', () => {
@@ -23,6 +23,23 @@ describe('getMarkerLegendSvgMarkup', () => {
     const markup = getMarkerLegendSvgMarkup('present', { width: 10, height: 16 });
     expect(markup).toContain('width="10"');
     expect(markup).toContain('height="16"');
+  });
+});
+
+describe('getDominantMarkerTone', () => {
+  it('returns present for empty groups', () => {
+    expect(getDominantMarkerTone([])).toBe('present');
+  });
+
+  it('uses the most frequent marker tone', () => {
+    expect(getDominantMarkerTone(['future', 'future', 'present'])).toBe('future');
+    expect(getDominantMarkerTone(['past', 'past', 'future'])).toBe('past');
+  });
+
+  it('keeps present, future, past tie priority when counts are equal', () => {
+    expect(getDominantMarkerTone(['past', 'future'])).toBe('future');
+    expect(getDominantMarkerTone(['past', 'present'])).toBe('present');
+    expect(getDominantMarkerTone(['past', 'future', 'present'])).toBe('present');
   });
 });
 

--- a/src/app/lib/mapIconUtils.ts
+++ b/src/app/lib/mapIconUtils.ts
@@ -259,19 +259,19 @@ export const getMarkerDistanceBucket = (distanceDays: number) => {
 export const getDominantMarkerTone = (tones: MarkerTone[]): MarkerTone => {
   if (tones.length === 0) return 'present';
 
-  let hasPresent = false;
-  let hasFuture = false;
-  let hasPast = false;
+  const counts: Record<MarkerTone, number> = {
+    past: 0,
+    present: 0,
+    future: 0,
+  };
 
   tones.forEach(tone => {
-    if (tone === 'present') hasPresent = true;
-    else if (tone === 'future') hasFuture = true;
-    else hasPast = true;
+    counts[tone] += 1;
   });
 
-  if (hasPresent) return 'present';
-  if (hasFuture) return 'future';
-  return hasPast ? 'past' : 'present';
+  return (['present', 'future', 'past'] as const).reduce((dominantTone, tone) =>
+    counts[tone] > counts[dominantTone] ? tone : dominantTone
+  );
 };
 
 export const createMarkerIcon = (


### PR DESCRIPTION
## Summary
- restore count-based dominant marker tone selection for grouped markers
- preserve existing tie priority: present, then future, then past
- add regression coverage for mixed-tone grouped markers

## Validation
- bun run test:unit -- src/app/__tests__/lib/mapIconUtils.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint
- bun run build