### PR TITLE
Fix deletion dialog modal hooks

### DIFF
--- a/src/app/admin/components/DeleteWarningDialog.tsx
+++ b/src/app/admin/components/DeleteWarningDialog.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import { LinkedExpense } from '@/app/lib/costLinkCleanup';
 import { formatCurrency, formatDate } from '@/app/lib/costUtils';
 import { useDialog } from '@react-aria/dialog';
-import { useModal, OverlayContainer, useOverlay, usePreventScroll } from '@react-aria/overlays';
+import { ariaHideOutside, OverlayContainer, useModal, useOverlay, usePreventScroll } from '@react-aria/overlays';
 import { FocusScope } from '@react-aria/focus';
 
 interface DeleteWarningDialogProps {
@@ -16,6 +16,28 @@ interface DeleteWarningDialogProps {
 }
 
 export default function DeleteWarningDialog({
+  isOpen,
+  itemType,
+  itemName,
+  linkedExpenses,
+  onChoice
+}: DeleteWarningDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <OverlayContainer>
+      <DeleteWarningDialogContent
+        isOpen={isOpen}
+        itemType={itemType}
+        itemName={itemName}
+        linkedExpenses={linkedExpenses}
+        onChoice={onChoice}
+      />
+    </OverlayContainer>
+  );
+}
+
+function DeleteWarningDialogContent({
   isOpen,
   itemType,
   itemName,
@@ -34,7 +56,7 @@ export default function DeleteWarningDialog({
     shouldCloseOnInteractOutside: () => true,
   }, ref);
   usePreventScroll();
-  useModal();
+  const { modalProps } = useModal();
   const { dialogProps, titleProps } = useDialog({
     'aria-label': `Delete ${itemType}`
   }, ref);
@@ -51,17 +73,20 @@ export default function DeleteWarningDialog({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [isOpen, onChoice]);
 
-  if (!isOpen) return null;
+  useEffect(() => {
+    if (!isOpen || !ref.current) return;
+    return ariaHideOutside([ref.current]);
+  }, [isOpen]);
 
   const totalAmount = linkedExpenses.reduce((sum, expense) => sum + expense.amount, 0);
   const currency = linkedExpenses[0]?.currency || 'EUR';
 
   return (
-    <OverlayContainer>
-      <FocusScope contain restoreFocus autoFocus>
-        <div {...underlayProps} className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <FocusScope contain restoreFocus autoFocus>
+      <div {...underlayProps} className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div
             {...overlayProps}
+            {...modalProps}
             {...dialogProps}
             ref={ref}
             className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto outline-none"
@@ -208,7 +233,6 @@ export default function DeleteWarningDialog({
             </div>
           </div>
         </div>
-      </FocusScope>
-    </OverlayContainer>
+    </FocusScope>
   );
 }

--- a/src/app/admin/components/ReassignmentDialog.tsx
+++ b/src/app/admin/components/ReassignmentDialog.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import { LinkedExpense } from '@/app/lib/costLinkCleanup';
 import { formatCurrency } from '@/app/lib/costUtils';
 import { useDialog } from '@react-aria/dialog';
-import { useModal, OverlayContainer, useOverlay, usePreventScroll } from '@react-aria/overlays';
+import { ariaHideOutside, OverlayContainer, useModal, useOverlay, usePreventScroll } from '@react-aria/overlays';
 import { FocusScope } from '@react-aria/focus';
 
 interface ReassignmentDialogProps {
@@ -27,6 +27,32 @@ export default function ReassignmentDialog({
   onReassign,
   onCancel
 }: ReassignmentDialogProps) {
+  if (!isOpen) return null;
+
+  return (
+    <OverlayContainer>
+      <ReassignmentDialogContent
+        isOpen={isOpen}
+        itemType={itemType}
+        fromItemName={fromItemName}
+        linkedExpenses={linkedExpenses}
+        availableItems={availableItems}
+        onReassign={onReassign}
+        onCancel={onCancel}
+      />
+    </OverlayContainer>
+  );
+}
+
+function ReassignmentDialogContent({
+  isOpen,
+  itemType,
+  fromItemName,
+  linkedExpenses,
+  availableItems,
+  onReassign,
+  onCancel
+}: ReassignmentDialogProps) {
   const [selectedItemId, setSelectedItemId] = useState<string>('');
   const ref = useRef<HTMLDivElement>(null);
 
@@ -39,7 +65,7 @@ export default function ReassignmentDialog({
     shouldCloseOnInteractOutside: () => true,
   }, ref);
   usePreventScroll();
-  useModal();
+  const { modalProps } = useModal();
   const { dialogProps, titleProps } = useDialog({
     'aria-label': `Reassign Linked Expenses`
   }, ref);
@@ -56,7 +82,10 @@ export default function ReassignmentDialog({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [isOpen, onCancel]);
 
-  if (!isOpen) return null;
+  useEffect(() => {
+    if (!isOpen || !ref.current) return;
+    return ariaHideOutside([ref.current]);
+  }, [isOpen]);
 
   const totalAmount = linkedExpenses.reduce((sum, expense) => sum + expense.amount, 0);
   const currency = linkedExpenses[0]?.currency || 'EUR';
@@ -69,11 +98,11 @@ export default function ReassignmentDialog({
   };
 
   return (
-    <OverlayContainer>
-      <FocusScope contain restoreFocus autoFocus>
-        <div {...underlayProps} className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <FocusScope contain restoreFocus autoFocus>
+      <div {...underlayProps} className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
           <div
             {...overlayProps}
+            {...modalProps}
             {...dialogProps}
             ref={ref}
             className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto outline-none"
@@ -195,7 +224,6 @@ export default function ReassignmentDialog({
             </div>
           </div>
         </div>
-      </FocusScope>
-    </OverlayContainer>
+    </FocusScope>
   );
 }

--- a/src/app/admin/components/__tests__/DeleteExpenseLinkDialogs.test.tsx
+++ b/src/app/admin/components/__tests__/DeleteExpenseLinkDialogs.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import DeleteWarningDialog from '@/app/admin/components/DeleteWarningDialog';
+import ReassignmentDialog from '@/app/admin/components/ReassignmentDialog';
+import type { LinkedExpense } from '@/app/lib/costLinkCleanup';
+
+const linkedExpenses: LinkedExpense[] = [
+  {
+    id: 'expense-1',
+    description: 'Hotel deposit',
+    amount: 125,
+    currency: 'EUR',
+    date: '2026-02-03',
+    costTrackerId: 'cost-trip-1',
+    costTrackerTitle: 'Winter trip',
+  },
+];
+
+describe('expense-link deletion dialogs', () => {
+  it('renders the delete warning dialog without requiring an ancestor modal provider', async () => {
+    expect(() => {
+      render(<DeleteWarningDialogFixture />);
+    }).not.toThrow();
+
+    const dialog = screen.getByRole('dialog', { name: /delete location/i });
+    expect(dialog).toHaveAttribute('data-ismodal', 'true');
+    expect(screen.getByText(/Linked Expenses Found/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('background-content').parentElement).toHaveAttribute('aria-hidden', 'true'));
+  });
+
+  it('renders the reassignment dialog without requiring an ancestor modal provider', async () => {
+    expect(() => {
+      render(<ReassignmentDialogFixture />);
+    }).not.toThrow();
+
+    const dialog = screen.getByRole('dialog', { name: /reassign linked expenses/i });
+    expect(dialog).toHaveAttribute('data-ismodal', 'true');
+    expect(screen.getByLabelText(/Lyon to Marseille/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByTestId('background-content').parentElement).toHaveAttribute('aria-hidden', 'true'));
+  });
+});
+
+function DeleteWarningDialogFixture() {
+  return (
+    <>
+      <main data-testid="background-content">Background content</main>
+      <DeleteWarningDialog
+        isOpen
+        itemType="location"
+        itemName="Paris"
+        linkedExpenses={linkedExpenses}
+        onChoice={jest.fn()}
+      />
+    </>
+  );
+}
+
+function ReassignmentDialogFixture() {
+  return (
+    <>
+      <main data-testid="background-content">Background content</main>
+      <ReassignmentDialog
+        isOpen
+        itemType="route"
+        fromItemName="Paris to Lyon"
+        linkedExpenses={linkedExpenses}
+        availableItems={[{ id: 'route-2', name: 'Lyon to Marseille' }]}
+        onReassign={jest.fn()}
+        onCancel={jest.fn()}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- remove broken useModal calls from delete/reassignment dialogs that run before their OverlayContainer exists
- keep React Aria scroll locking conditional on isOpen
- add render regression tests for both linked-expense deletion dialogs

## Validation
- bun run test:unit -- src/app/admin/components/__tests__/DeleteExpenseLinkDialogs.test.tsx --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"
- bun run lint
- bun run build