### PR TITLE
[codex] Restrict Instagram import to admin domain

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -15,6 +15,7 @@ services:
       - NEXT_PUBLIC_EMBED_DOMAIN=${EMBED_DOMAIN}
       - ADMIN_DOMAIN=${ADMIN_DOMAIN}
       - EMBED_DOMAIN=${EMBED_DOMAIN}
+      - INSTAGRAM_APP_ID=${INSTAGRAM_APP_ID}
     restart: unless-stopped
     networks:
       - travel-network
@@ -41,7 +42,6 @@ services:
       - NEXT_PUBLIC_EMBED_DOMAIN=${EMBED_DOMAIN}
       - ADMIN_DOMAIN=${ADMIN_DOMAIN}
       - EMBED_DOMAIN=${EMBED_DOMAIN}
-      - INSTAGRAM_APP_ID=${INSTAGRAM_APP_ID}
     restart: unless-stopped
     networks:
       - travel-network

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -15,7 +15,6 @@ services:
       - NEXT_PUBLIC_EMBED_DOMAIN=${EMBED_DOMAIN}
       - ADMIN_DOMAIN=${ADMIN_DOMAIN}
       - EMBED_DOMAIN=${EMBED_DOMAIN}
-      - INSTAGRAM_APP_ID=${INSTAGRAM_APP_ID}
     restart: unless-stopped
     networks:
       - travel-network

--- a/src/app/__tests__/api/instagram-auth-cache.test.ts
+++ b/src/app/__tests__/api/instagram-auth-cache.test.ts
@@ -37,8 +37,8 @@ const instagramPayload = {
   },
 };
 
-const buildRequest = (host: string): NextRequest =>
-  new NextRequest(`https://${host}/api/instagram?username=demo_user`, {
+const buildRequest = (host: string, username = 'demo_user'): NextRequest =>
+  new NextRequest(`https://${host}/api/instagram?username=${encodeURIComponent(username)}`, {
     headers: { host },
   });
 
@@ -75,26 +75,16 @@ describe('instagram API auth and cache boundary', () => {
     }
   });
 
-  it('does not attach operator Instagram cookies for public requests', async () => {
+  it('rejects public requests before reaching Instagram', async () => {
     mockIsAdminDomain.mockResolvedValue(false);
 
     const response = await GET(buildRequest('public.example.test'));
     const result = await response.json();
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get('Cache-Control')).toBe(
-      'public, s-maxage=600, stale-while-revalidate=300'
-    );
-    expect(result.posts).toHaveLength(1);
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://www.instagram.com/api/v1/users/web_profile_info/?username=demo_user',
-      expect.objectContaining({
-        headers: expect.not.objectContaining({
-          Cookie: expect.any(String),
-        }),
-        next: { revalidate: 600 },
-      })
-    );
+    expect(response.status).toBe(403);
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+    expect(result).toEqual({ error: 'Instagram import is only available on the admin domain.' });
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   it('attaches operator Instagram cookies only for admin-domain requests', async () => {
@@ -122,6 +112,22 @@ describe('instagram API auth and cache boundary', () => {
         headers: expect.objectContaining({
           Cookie: 'sessionid=operator-session; csrftoken=operator-csrf; ds_user_id=12345',
         }),
+      })
+    );
+  });
+
+  it('normalizes Instagram URL usernames for admin-domain requests', async () => {
+    mockIsAdminDomain.mockResolvedValue(true);
+
+    const response = await GET(
+      buildRequest('admin.example.test', 'https://www.instagram.com/demo_user/?hl=en')
+    );
+
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://www.instagram.com/api/v1/users/web_profile_info/?username=demo_user',
+      expect.objectContaining({
+        cache: 'no-store',
       })
     );
   });

--- a/src/app/api/instagram/route.ts
+++ b/src/app/api/instagram/route.ts
@@ -20,6 +20,9 @@ const INSTAGRAM_HEADERS = {
   'Accept': 'application/json',
   'X-Requested-With': 'XMLHttpRequest'
 };
+const PRIVATE_NO_STORE_HEADERS = {
+  'Cache-Control': 'private, no-store'
+};
 
 const getInstagramPayloadFailureMessage = (payload: unknown): string | null => {
   if (typeof payload !== 'object' || payload === null || Array.isArray(payload)) {
@@ -41,26 +44,35 @@ const getInstagramPayloadFailureMessage = (payload: unknown): string | null => {
 };
 
 export async function GET(request: NextRequest) {
+  const isAdminRequest = await isAdminDomain();
+  if (!isAdminRequest) {
+    return NextResponse.json(
+      { error: 'Instagram import is only available on the admin domain.' },
+      {
+        status: 403,
+        headers: PRIVATE_NO_STORE_HEADERS,
+      }
+    );
+  }
+
   const { searchParams } = new URL(request.url);
   const rawUsername = searchParams.get('username') ?? '';
   const username = normalizeInstagramUsername(rawUsername);
   const instagramAppId = process.env.INSTAGRAM_APP_ID?.trim() || DEFAULT_INSTAGRAM_APP_ID;
   const envCookieHeader = buildInstagramCookieHeaderFromEnv();
-  let isAdminRequest: boolean | undefined;
-  if (envCookieHeader) {
-    isAdminRequest = await isAdminDomain();
-  }
-  const cookieHeader = isAdminRequest ? envCookieHeader : undefined;
-  const usePrivateCache = Boolean(cookieHeader);
+  const cookieHeader = envCookieHeader || undefined;
 
   if (!username) {
-    return NextResponse.json({ error: 'Username is required' }, { status: 400 });
+    return NextResponse.json(
+      { error: 'Username is required' },
+      { status: 400, headers: PRIVATE_NO_STORE_HEADERS }
+    );
   }
 
   if (!isValidInstagramUsername(username)) {
     return NextResponse.json(
       { error: 'Invalid Instagram username format' },
-      { status: 400 }
+      { status: 400, headers: PRIVATE_NO_STORE_HEADERS }
     );
   }
 
@@ -80,11 +92,7 @@ export async function GET(request: NextRequest) {
         },
       };
 
-      if (usePrivateCache) {
-        fetchOptions.cache = 'no-store';
-      } else {
-        fetchOptions.next = { revalidate: 600 };
-      }
+      fetchOptions.cache = 'no-store';
 
       let response: Response;
       try {
@@ -151,47 +159,44 @@ export async function GET(request: NextRequest) {
         },
         {
           headers: {
-            'Cache-Control': usePrivateCache
-              ? 'private, no-store'
-              : 'public, s-maxage=600, stale-while-revalidate=300'
+            ...PRIVATE_NO_STORE_HEADERS
           }
         }
       );
     }
 
     if (sawLoginRequirement) {
-      isAdminRequest ??= await isAdminDomain();
-
       return NextResponse.json(
         {
-          error: isAdminRequest
-            ? 'Instagram is requiring a logged-in session. Configure INSTAGRAM_SESSIONID (and optionally INSTAGRAM_CSRFTOKEN / INSTAGRAM_DS_USER_ID).'
-            : 'This Instagram profile is not publicly accessible.'
+          error: 'Instagram is requiring a logged-in session. Configure INSTAGRAM_SESSIONID (and optionally INSTAGRAM_CSRFTOKEN / INSTAGRAM_DS_USER_ID).'
         },
-        { status: 403 }
+        { status: 403, headers: PRIVATE_NO_STORE_HEADERS }
       );
     }
 
     if (sawRateLimit) {
       return NextResponse.json(
         { error: 'Instagram temporarily rate-limited profile requests. Try again shortly.' },
-        { status: 429 }
+        { status: 429, headers: PRIVATE_NO_STORE_HEADERS }
       );
     }
 
     if (sawNotFound) {
       return NextResponse.json(
         { error: 'Instagram profile not found or not publicly accessible.' },
-        { status: 404 }
+        { status: 404, headers: PRIVATE_NO_STORE_HEADERS }
       );
     }
 
     return NextResponse.json(
       { error: 'Failed to fetch Instagram profile from available endpoints' },
-      { status: 502 }
+      { status: 502, headers: PRIVATE_NO_STORE_HEADERS }
     );
   } catch (error) {
     console.error('Error fetching Instagram profile:', error);
-    return NextResponse.json({ error: 'Failed to fetch Instagram profile' }, { status: 500 });
+    return NextResponse.json(
+      { error: 'Failed to fetch Instagram profile' },
+      { status: 500, headers: PRIVATE_NO_STORE_HEADERS }
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Require `isAdminDomain()` before `/api/instagram` parses import requests or fetches Instagram upstream endpoints.
- Mark all Instagram import responses `Cache-Control: private, no-store` and keep operator session cookies available only after the admin-domain boundary passes.
- Remove `INSTAGRAM_APP_ID` from the public embed service in `deploy/docker-compose.prod.yml`; the admin service still receives it.

## Security proof

- Public/embed requests now return `403` before any Instagram fetch. The focused regression test asserts `global.fetch` is not called for a public host.
- Admin requests still follow the Instagram fetch path with `cache: 'no-store'` and optional operator cookies when configured.
- Admin URL username normalization is covered by the route test, and the existing `instagramImportUtils` tests confirm lookalike Instagram hosts are rejected.
- I confirmed the related main-branch fixes mentioned in the handoff are already present: public `/api/travel-data` filtering clears `instagramUsername`, and `LocationPosts` declares hooks before the `isVisible` early return.

## Validation

- `bun run test:unit -- src/app/__tests__/api/instagram-auth-cache.test.ts src/app/__tests__/lib/instagramImportUtils.test.ts src/app/__tests__/api/travel-data-auth-cache.test.ts --modulePathIgnorePatterns="<rootDir>/.worktrees" --modulePathIgnorePatterns="<rootDir>/.next"` passed: 3 suites, 19 tests.
- `bun run lint` passed with existing warnings only: 0 errors, 45 warnings.
- `bun run build` passed. Build emitted the existing Turbopack NFT warning for `next.config.js` -> `dataDirectory.ts` -> `api/wikipedia/refresh/route.ts`.
- `git diff --check` passed.